### PR TITLE
Feat : 게시물, 용어, 뉴스, 카테고리, 이미지 엔터티 추가

### DIFF
--- a/src/main/java/com/ripple/BE/category/domain/Category.java
+++ b/src/main/java/com/ripple/BE/category/domain/Category.java
@@ -1,0 +1,47 @@
+package com.ripple.BE.category.domain;
+
+import com.ripple.BE.global.entity.BaseEntity;
+import com.ripple.BE.news.domain.NewsCategory;
+import com.ripple.BE.post.domain.PostCategory;
+import com.ripple.BE.term.domain.TermCategory;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "categories")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Category extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name; // 카테고리명
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostCategory> postCategoryList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<NewsCategory> newsCategoryList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TermCategory> termCategoryList = new ArrayList<>();
+}

--- a/src/main/java/com/ripple/BE/category/domain/Category.java
+++ b/src/main/java/com/ripple/BE/category/domain/Category.java
@@ -1,19 +1,12 @@
 package com.ripple.BE.category.domain;
 
 import com.ripple.BE.global.entity.BaseEntity;
-import com.ripple.BE.news.domain.NewsCategory;
-import com.ripple.BE.post.domain.PostCategory;
-import com.ripple.BE.term.domain.TermCategory;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,13 +28,4 @@ public class Category extends BaseEntity {
 
     @Column(name = "name", nullable = false)
     private String name; // 카테고리명
-
-    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PostCategory> postCategoryList = new ArrayList<>();
-
-    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<NewsCategory> newsCategoryList = new ArrayList<>();
-
-    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<TermCategory> termCategoryList = new ArrayList<>();
 }

--- a/src/main/java/com/ripple/BE/chatbot/domain/ChatMessage.java
+++ b/src/main/java/com/ripple/BE/chatbot/domain/ChatMessage.java
@@ -1,0 +1,47 @@
+package com.ripple.BE.chatbot.domain;
+
+import com.ripple.BE.chatbot.domain.type.Sender;
+import com.ripple.BE.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "chat_messages")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChatMessage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Size(min = 1)
+    @Column(name = "message", nullable = false)
+    private String message;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sender", nullable = false)
+    private Sender sender; // 메시지 송신자
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_session_id")
+    private ChatSession chatSession;
+}

--- a/src/main/java/com/ripple/BE/chatbot/domain/ChatSession.java
+++ b/src/main/java/com/ripple/BE/chatbot/domain/ChatSession.java
@@ -1,0 +1,43 @@
+package com.ripple.BE.chatbot.domain;
+
+import com.ripple.BE.global.entity.BaseEntity;
+import com.ripple.BE.member.domain.Member;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "chat_sessions")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChatSession extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @OneToMany(mappedBy = "chatSession", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatMessage> chatMessages = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member; // 챗봇 채팅 세션을 생성한 사용자
+}

--- a/src/main/java/com/ripple/BE/chatbot/domain/type/Sender.java
+++ b/src/main/java/com/ripple/BE/chatbot/domain/type/Sender.java
@@ -1,0 +1,6 @@
+package com.ripple.BE.chatbot.domain.type;
+
+public enum Sender {
+    CHATBOT,
+    USER
+}

--- a/src/main/java/com/ripple/BE/global/dto/response/ApiResponse.java
+++ b/src/main/java/com/ripple/BE/global/dto/response/ApiResponse.java
@@ -1,43 +1,40 @@
 package com.ripple.BE.global.dto.response;
 
 import java.util.Collections;
-
 import lombok.Builder;
 
 @Builder
-public record ApiResponse<T>(
-	Boolean isSuccess,
-	String code,
-	String message,
-	T results
-) {
-	public static final ApiResponse<Object> EMPTY_RESPONSE = ApiResponse.builder()
-		.isSuccess(true)
-		.code("REQUEST_OK")
-		.message("요청이 승인되었습니다.")
-		.results(Collections.EMPTY_MAP)
-		.build();
+public record ApiResponse<T>(Boolean isSuccess, String code, String message, T results) {
+    public static final ApiResponse<Object> EMPTY_RESPONSE =
+            ApiResponse.builder()
+                    .isSuccess(true)
+                    .code("REQUEST_OK")
+                    .message("요청이 승인되었습니다.")
+                    .results(Collections.EMPTY_MAP)
+                    .build();
 
-	public static final ApiResponse<Object> JSON_ROLE_ERROR = ApiResponse.builder()
-		.isSuccess(false)
-		.code("JSON_ROLE_ERROR")
-		.message("가진 권한으로는 실행할 수 없는 기능입니다.")
-		.results(Collections.EMPTY_MAP)
-		.build();
+    public static final ApiResponse<Object> JSON_ROLE_ERROR =
+            ApiResponse.builder()
+                    .isSuccess(false)
+                    .code("JSON_ROLE_ERROR")
+                    .message("가진 권한으로는 실행할 수 없는 기능입니다.")
+                    .results(Collections.EMPTY_MAP)
+                    .build();
 
-	public static final ApiResponse<Object> JSON_AUTH_ERROR = ApiResponse.builder()
-		.isSuccess(false)
-		.code("JSON_AUTH_ERROR")
-		.message("로그인 후 다시 접근해주시기 바랍니다.")
-		.results(Collections.EMPTY_MAP)
-		.build();
+    public static final ApiResponse<Object> JSON_AUTH_ERROR =
+            ApiResponse.builder()
+                    .isSuccess(false)
+                    .code("JSON_AUTH_ERROR")
+                    .message("로그인 후 다시 접근해주시기 바랍니다.")
+                    .results(Collections.EMPTY_MAP)
+                    .build();
 
-	public static <T> ApiResponse<Object> from(T dto) {
-		return ApiResponse.builder()
-			.isSuccess(true)
-			.code("REQUEST_OK")
-			.message("request succeeded")
-			.results(dto)
-			.build();
-	}
+    public static <T> ApiResponse<Object> from(T dto) {
+        return ApiResponse.builder()
+                .isSuccess(true)
+                .code("REQUEST_OK")
+                .message("request succeeded")
+                .results(dto)
+                .build();
+    }
 }

--- a/src/main/java/com/ripple/BE/global/entity/BaseEntity.java
+++ b/src/main/java/com/ripple/BE/global/entity/BaseEntity.java
@@ -1,29 +1,25 @@
 package com.ripple.BE.global.entity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
-
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
-
 @Getter
-@MappedSuperclass	// 이 클래스를 직접 테이블로 매핑하지 않고, 자식 클래스에 매핑 정보를 전달하도록 설정
-@EntityListeners(AuditingEntityListener.class)	// JPA 엔티티의 상태 변화를 감지하여 Auditing(자동 필드 값 설정)을 수행하는 리스너를 추가
+@MappedSuperclass // 이 클래스를 직접 테이블로 매핑하지 않고, 자식 클래스에 매핑 정보를 전달하도록 설정
+@EntityListeners(
+        AuditingEntityListener.class) // JPA 엔티티의 상태 변화를 감지하여 Auditing(자동 필드 값 설정)을 수행하는 리스너를 추가
 public abstract class BaseEntity {
 
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdDate;
 
-	@CreatedDate
-	@Column(updatable = false, nullable = false)
-	private LocalDateTime createdDate;
-
-	@LastModifiedDate
-	@Column(nullable = false)
-	private LocalDateTime modifiedDate;
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedDate;
 }

--- a/src/main/java/com/ripple/BE/global/exception/ApiException.java
+++ b/src/main/java/com/ripple/BE/global/exception/ApiException.java
@@ -1,4 +1,3 @@
 package com.ripple.BE.global.exception;
 
-public class ApiException {
-}
+public class ApiException {}

--- a/src/main/java/com/ripple/BE/global/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/ripple/BE/global/exception/errorcode/ErrorCode.java
@@ -2,31 +2,26 @@ package com.ripple.BE.global.exception.errorcode;
 
 import org.springframework.http.HttpStatus;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-
 public interface ErrorCode {
 
-	/**
-	 * enum 클래스 이름을 return
-	 *
-	 * @return enum 클래스 이름
-	 */
-	String name();
+    /**
+     * enum 클래스 이름을 return
+     *
+     * @return enum 클래스 이름
+     */
+    String name();
 
-	/**
-	 * 할당된 HttpStatus 반환
-	 *
-	 * @return HttpStatus
-	 */
-	HttpStatus getHttpStatus();
+    /**
+     * 할당된 HttpStatus 반환
+     *
+     * @return HttpStatus
+     */
+    HttpStatus getHttpStatus();
 
-	/**
-	 * 지정된 메시지 반환
-	 *
-	 * @return message
-	 */
-	String getMessage();
-
+    /**
+     * 지정된 메시지 반환
+     *
+     * @return message
+     */
+    String getMessage();
 }

--- a/src/main/java/com/ripple/BE/global/exception/errorcode/GlobalErrorCode.java
+++ b/src/main/java/com/ripple/BE/global/exception/errorcode/GlobalErrorCode.java
@@ -1,23 +1,19 @@
 package com.ripple.BE.global.exception.errorcode;
 
-import org.springframework.http.HttpStatus;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
-/**
- * Dto @Valid 관련 error 해결을 위한 enum class
- */
+/** Dto @Valid 관련 error 해결을 위한 enum class */
 @Getter
 @RequiredArgsConstructor
 public enum GlobalErrorCode implements ErrorCode {
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not exists"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
+    FILE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "file convert failed"),
+    ;
 
-	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included"),
-	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not exists"),
-	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
-	FILE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "file convert failed"),
-	;
-
-	private final HttpStatus httpStatus;
-	private final String message;
+    private final HttpStatus httpStatus;
+    private final String message;
 }

--- a/src/main/java/com/ripple/BE/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/ripple/BE/global/exception/handler/GlobalExceptionHandler.java
@@ -1,7 +1,12 @@
 package com.ripple.BE.global.exception.handler;
 
+import com.ripple.BE.global.exception.errorcode.ErrorCode;
+import com.ripple.BE.global.exception.errorcode.GlobalErrorCode;
+import com.ripple.BE.global.exception.response.ErrorResponse;
+import com.ripple.BE.global.exception.response.ErrorResponse.ValidationError;
+import com.ripple.BE.global.exception.response.ErrorResponse.ValidationErrors;
+import io.micrometer.common.lang.NonNull;
 import java.util.List;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -12,113 +17,104 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import com.ripple.BE.global.exception.errorcode.ErrorCode;
-import com.ripple.BE.global.exception.errorcode.GlobalErrorCode;
-import com.ripple.BE.global.exception.response.ErrorResponse;
-import com.ripple.BE.global.exception.response.ErrorResponse.ValidationError;
-import com.ripple.BE.global.exception.response.ErrorResponse.ValidationErrors;
-
-import io.micrometer.common.lang.NonNull;
-
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
-	/**
-	 * 커스텀 예외 코드 예시
-	 * @ExceptionHandler(PostNotFoundException.class)
-	 *        public ResponseEntity<Object> handleReviewNotFound(PostNotFoundException e) {
-	 * 		return handleExceptionInternal(e.getErrorCode());
-	 *    }
-	 */
+    /**
+     * 커스텀 예외 코드 예시 @ExceptionHandler(PostNotFoundException.class) public ResponseEntity<Object>
+     * handleReviewNotFound(PostNotFoundException e) { return
+     * handleExceptionInternal(e.getErrorCode()); }
+     */
 
-	/**
-	 * @Valid 관련 예외 처리 (DTO 검증 실패 시 발생)
-	 * @param e MethodArgumentNotValidException 예외 객체
-	 * @param headers 요청 헤더
-	 * @param status HTTP 상태 코드
-	 * @param request WebRequest 객체
-	 * @return 처리된 예외 응답
-	 */
-	@Override
-	public ResponseEntity<Object> handleMethodArgumentNotValid(
-		@NonNull MethodArgumentNotValidException e,
-		@NonNull HttpHeaders headers,
-		@NonNull HttpStatusCode status,
-		@NonNull WebRequest request) {
-		return handleExceptionInternal(e);
-	}
+    /**
+     * @Valid 관련 예외 처리 (DTO 검증 실패 시 발생)
+     *
+     * @param e MethodArgumentNotValidException 예외 객체
+     * @param headers 요청 헤더
+     * @param status HTTP 상태 코드
+     * @param request WebRequest 객체
+     * @return 처리된 예외 응답
+     */
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            @NonNull MethodArgumentNotValidException e,
+            @NonNull HttpHeaders headers,
+            @NonNull HttpStatusCode status,
+            @NonNull WebRequest request) {
+        return handleExceptionInternal(e);
+    }
 
-	@ExceptionHandler(IllegalArgumentException.class)
-	public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException e) {
-		return handleExceptionInternal(GlobalErrorCode.INVALID_PARAMETER);
-	}
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException e) {
+        return handleExceptionInternal(GlobalErrorCode.INVALID_PARAMETER);
+    }
 
-	/**
-	 * 모든 예외를 처리하는 기본 예외 처리기
-	 * @param e 발생한 예외 객체
-	 * @return 처리된 예외 응답
-	 */
-	@ExceptionHandler(Exception.class)
-	public ResponseEntity<Object> handleAllException(Exception e) {
-		return handleExceptionInternal(GlobalErrorCode.INTERNAL_SERVER_ERROR);
-	}
+    /**
+     * 모든 예외를 처리하는 기본 예외 처리기
+     *
+     * @param e 발생한 예외 객체
+     * @return 처리된 예외 응답
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleAllException(Exception e) {
+        return handleExceptionInternal(GlobalErrorCode.INTERNAL_SERVER_ERROR);
+    }
 
-	/**
-	 * 예외 처리 결과를 생성하는 내부 메서드
-	 * @param errorCode 처리할 에러 코드
-	 * @return 생성된 ErrorResponse 객체
-	 */
-	private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
-		return ResponseEntity.status(errorCode.getHttpStatus())
-			.body(makeErrorResponse(errorCode));
-	}
+    /**
+     * 예외 처리 결과를 생성하는 내부 메서드
+     *
+     * @param errorCode 처리할 에러 코드
+     * @return 생성된 ErrorResponse 객체
+     */
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(makeErrorResponse(errorCode));
+    }
 
-	/**
-	 * ErrorResponse 객체를 생성하는 메서드
-	 * @param errorCode 처리할 에러 코드
-	 * @return 생성된 ErrorResponse 객체
-	 */
-	private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
-		return ErrorResponse.builder()
-			.isSuccess(false)
-			.code(errorCode.name())
-			.message(errorCode.getMessage())
-			.results(new ValidationErrors(null))
-			.build();
-	}
+    /**
+     * ErrorResponse 객체를 생성하는 메서드
+     *
+     * @param errorCode 처리할 에러 코드
+     * @return 생성된 ErrorResponse 객체
+     */
+    private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .isSuccess(false)
+                .code(errorCode.name())
+                .message(errorCode.getMessage())
+                .results(new ValidationErrors(null))
+                .build();
+    }
 
-	/**
-	 * BindException (DTO 검증 실패) 처리
-	 * @param e BindException 예외 객체
-	 * @return 처리된 예외 응답
-	 */
-	private ResponseEntity<Object> handleExceptionInternal(BindException e) {
-		return ResponseEntity.status(GlobalErrorCode.INVALID_PARAMETER.getHttpStatus())
-			.body(makeErrorResponse(e));
-	}
+    /**
+     * BindException (DTO 검증 실패) 처리
+     *
+     * @param e BindException 예외 객체
+     * @return 처리된 예외 응답
+     */
+    private ResponseEntity<Object> handleExceptionInternal(BindException e) {
+        return ResponseEntity.status(GlobalErrorCode.INVALID_PARAMETER.getHttpStatus())
+                .body(makeErrorResponse(e));
+    }
 
-	/**
-	 * BindException에서 발생한 유효성 오류를 ErrorResponse로 변환
-	 * @param e BindException 예외 객체
-	 * @return 생성된 ErrorResponse 객체
-	 */
-	private ErrorResponse makeErrorResponse(BindException e) {
-		final List<ValidationError> validationErrorList = e.getBindingResult()
-			.getFieldErrors()
-			.stream()
-			.map(ValidationError::from)
-			.toList();
+    /**
+     * BindException에서 발생한 유효성 오류를 ErrorResponse로 변환
+     *
+     * @param e BindException 예외 객체
+     * @return 생성된 ErrorResponse 객체
+     */
+    private ErrorResponse makeErrorResponse(BindException e) {
+        final List<ValidationError> validationErrorList =
+                e.getBindingResult().getFieldErrors().stream().map(ValidationError::from).toList();
 
-		return getBuild(validationErrorList);
-	}
+        return getBuild(validationErrorList);
+    }
 
-	private static ErrorResponse getBuild(List<ValidationError> validationErrorList) {
-		return ErrorResponse.builder()
-			.isSuccess(false)
-			.code(GlobalErrorCode.INVALID_PARAMETER.name())
-			.message(GlobalErrorCode.INVALID_PARAMETER.getMessage())
-			.results(new ValidationErrors(validationErrorList))
-			.build();
-	}
-
+    private static ErrorResponse getBuild(List<ValidationError> validationErrorList) {
+        return ErrorResponse.builder()
+                .isSuccess(false)
+                .code(GlobalErrorCode.INVALID_PARAMETER.name())
+                .message(GlobalErrorCode.INVALID_PARAMETER.getMessage())
+                .results(new ValidationErrors(validationErrorList))
+                .build();
+    }
 }

--- a/src/main/java/com/ripple/BE/global/exception/response/ErrorResponse.java
+++ b/src/main/java/com/ripple/BE/global/exception/response/ErrorResponse.java
@@ -1,39 +1,28 @@
 package com.ripple.BE.global.exception.response;
 
-import java.util.List;
-
-import org.springframework.validation.FieldError;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
-
+import java.util.List;
 import lombok.Builder;
+import org.springframework.validation.FieldError;
 
 @Builder
 public record ErrorResponse(
-	Boolean isSuccess,
-	String code,
-	String message,
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)    //유효성 오류가 있을 때만 포함
-	ValidationErrors results
-) {
-	public record ValidationErrors(
-		List<ValidationError> validationErrors
-	) {
+        Boolean isSuccess,
+        String code,
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY) // 유효성 오류가 있을 때만 포함
+                ValidationErrors results) {
+    public record ValidationErrors(List<ValidationError> validationErrors) {}
 
-	}
-
-	//@Valid 오류의 경우 사용 - error 발생 이유
-	@Builder
-	public record ValidationError(
-		String field,
-		String message
-	) {
-		// Spring의 FieldError 객체를 ValidationError 객체로 변환
-		public static ValidationError from(final FieldError fieldError) {
-			return ValidationError.builder()
-				.field(fieldError.getField())
-				.message(fieldError.getDefaultMessage())
-				.build();
-		}
-	}
+    // @Valid 오류의 경우 사용 - error 발생 이유
+    @Builder
+    public record ValidationError(String field, String message) {
+        // Spring의 FieldError 객체를 ValidationError 객체로 변환
+        public static ValidationError from(final FieldError fieldError) {
+            return ValidationError.builder()
+                    .field(fieldError.getField())
+                    .message(fieldError.getDefaultMessage())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/ripple/BE/image/domain/Image.java
+++ b/src/main/java/com/ripple/BE/image/domain/Image.java
@@ -1,0 +1,43 @@
+package com.ripple.BE.image.domain;
+
+import com.ripple.BE.global.entity.BaseEntity;
+import com.ripple.BE.news.domain.News;
+import com.ripple.BE.post.domain.Post;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "images")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Image extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_id")
+    private News news;
+}

--- a/src/main/java/com/ripple/BE/member/domain/Member.java
+++ b/src/main/java/com/ripple/BE/member/domain/Member.java
@@ -1,17 +1,21 @@
 package com.ripple.BE.member.domain;
 
-import java.time.LocalDateTime;
-
+import com.ripple.BE.chatbot.domain.ChatSession;
+import com.ripple.BE.global.entity.BaseEntity;
 import com.ripple.BE.member.domain.type.AgeRange;
 import com.ripple.BE.member.domain.type.BusinessType;
 import com.ripple.BE.member.domain.type.Gender;
 import com.ripple.BE.member.domain.type.Job;
-import com.ripple.BE.member.domain.type.Role;
-import com.ripple.BE.global.entity.BaseEntity;
-
 import com.ripple.BE.member.domain.type.Level;
 import com.ripple.BE.member.domain.type.LoginType;
-
+import com.ripple.BE.member.domain.type.Role;
+import com.ripple.BE.news.domain.NewsScrap;
+import com.ripple.BE.post.domain.Comment;
+import com.ripple.BE.post.domain.Post;
+import com.ripple.BE.post.domain.PostLike;
+import com.ripple.BE.post.domain.PostScrap;
+import com.ripple.BE.term.domain.TermScrap;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -19,16 +23,19 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-
 import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Table(name="members")
+@Table(name = "members")
 @Getter
 @Builder
 @Entity
@@ -36,71 +43,90 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class Member extends BaseEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name="id", nullable = false)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
 
-	@Size(min = 5, max = 50)
-	@Column(name = "login_id", nullable = false)
-	private String loginId;	//식별 아이디
+    @Size(min = 5, max = 50)
+    @Column(name = "login_id", nullable = false)
+    private String loginId; // 식별 아이디
 
-	@Size(min = 8, max = 255)
-	@Column(name = "password", nullable = false)
-	private String password;
+    @Size(min = 8, max = 255)
+    @Column(name = "password", nullable = false)
+    private String password;
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "role", nullable = false)
-	private Role role;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private Role role;
 
-	@Size(min = 2, max = 20)
-	@Column(name = "name", nullable = false)
-	private String name;
+    @Size(min = 2, max = 20)
+    @Column(name = "name", nullable = false)
+    private String name;
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "business_type", nullable = false)
-	private BusinessType businessType;	//업종
+    @Enumerated(EnumType.STRING)
+    @Column(name = "business_type", nullable = false)
+    private BusinessType businessType; // 업종
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "job", nullable = false)
-	private Job job;	//직무
+    @Enumerated(EnumType.STRING)
+    @Column(name = "job", nullable = false)
+    private Job job; // 직무
 
-	@Column(name = "age_range")
-	private AgeRange ageRange;	//연령대
+    @Column(name = "age_range")
+    private AgeRange ageRange; // 연령대
 
-	@Column(name = "birthday")
-	private LocalDateTime birthday;
+    @Column(name = "birthday")
+    private LocalDateTime birthday;
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "gender")
-	private Gender gender;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender")
+    private Gender gender;
 
-	@Column(name = "profile_image_url", length = 255)
-	private String profileImageUrl;	//프로필 사진 URL
+    @Column(name = "profile_image_url", length = 255)
+    private String profileImageUrl; // 프로필 사진 URL
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "login_type", nullable = false)
-	private LoginType loginType;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "login_type", nullable = false)
+    private LoginType loginType;
 
-	@Size(min = 1, max = 255)
-	@Column(name = "profile_intro")
-	private String profileIntro;	//한줄 소개
+    @Size(min = 1, max = 255)
+    @Column(name = "profile_intro")
+    private String profileIntro; // 한줄 소개
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "current_level")
-	private Level currentLevel;	//현재 학습 단계
+    @Enumerated(EnumType.STRING)
+    @Column(name = "current_level")
+    private Level currentLevel; // 현재 학습 단계
 
-	@Column(name = "is_learning_alarm_allowed", nullable = false)
-	private boolean isLearningAlarmAllowed;	//학습 푸시 알람 여부
+    @Column(name = "is_learning_alarm_allowed", nullable = false)
+    private boolean isLearningAlarmAllowed; // 학습 푸시 알람 여부
 
-	@Column(name = "is_community_alarm_allowed", nullable = false)
-	private boolean isCoummunityAlarmAllowed;		//커뮤니티 푸시 알람 여부
+    @Column(name = "is_community_alarm_allowed", nullable = false)
+    private boolean isCoummunityAlarmAllowed; // 커뮤니티 푸시 알람 여부
 
-	@Column(name = "finished_learning_sets")
-	private Long finishedLearningSets;	//완료한 학습세트 개수
+    @Column(name = "finished_learning_sets")
+    private Long finishedLearningSets; // 완료한 학습세트 개수
 
-	@Column(name = "finished_quizzes")
-	private Long finishedQuizzes;	//완료한 퀴즈 개수
+    @Column(name = "finished_quizzes")
+    private Long finishedQuizzes; // 완료한 퀴즈 개수
 
+    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Post> postList = new ArrayList<>(); // 작성한 게시글 목록
 
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostScrap> postScrapList = new ArrayList<>(); // 스크랩한 게시글 목록
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostLike> postLikeList = new ArrayList<>(); // 좋아요한 게시글 목록
+
+    @OneToMany(mappedBy = "commenter", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> commentList = new ArrayList<>(); // 작성한 댓글 목록
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<NewsScrap> newsScrapList = new ArrayList<>(); // 스크랩한 뉴스 목록
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TermScrap> termScrapList = new ArrayList<>(); // 스크랩한 용어 목록
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatSession> chatSessionList = new ArrayList<>(); // 채팅 세션 목록
 }

--- a/src/main/java/com/ripple/BE/member/domain/type/AgeRange.java
+++ b/src/main/java/com/ripple/BE/member/domain/type/AgeRange.java
@@ -1,9 +1,7 @@
 package com.ripple.BE.member.domain.type;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-
 public enum AgeRange {
-	TEENS,  TWENTIES, THIRTIES
+    TEENS,
+    TWENTIES,
+    THIRTIES
 }

--- a/src/main/java/com/ripple/BE/member/domain/type/BusinessType.java
+++ b/src/main/java/com/ripple/BE/member/domain/type/BusinessType.java
@@ -1,5 +1,7 @@
 package com.ripple.BE.member.domain.type;
 
 public enum BusinessType {
-	MARKETING, RECRUITMENT, DESIGN
+    MARKETING,
+    RECRUITMENT,
+    DESIGN
 }

--- a/src/main/java/com/ripple/BE/member/domain/type/Gender.java
+++ b/src/main/java/com/ripple/BE/member/domain/type/Gender.java
@@ -1,5 +1,6 @@
 package com.ripple.BE.member.domain.type;
 
 public enum Gender {
-	MALE, FEMALE
+    MALE,
+    FEMALE
 }

--- a/src/main/java/com/ripple/BE/member/domain/type/Job.java
+++ b/src/main/java/com/ripple/BE/member/domain/type/Job.java
@@ -1,5 +1,7 @@
 package com.ripple.BE.member.domain.type;
 
 public enum Job {
-	DEVELOPER, DESIGNER, ENGINEER
+    DEVELOPER,
+    DESIGNER,
+    ENGINEER
 }

--- a/src/main/java/com/ripple/BE/member/domain/type/Level.java
+++ b/src/main/java/com/ripple/BE/member/domain/type/Level.java
@@ -1,5 +1,7 @@
 package com.ripple.BE.member.domain.type;
 
 public enum Level {
-	BEGINNER, INTERMEDIATE, ADVANCED
+    BEGINNER,
+    INTERMEDIATE,
+    ADVANCED
 }

--- a/src/main/java/com/ripple/BE/member/domain/type/LoginType.java
+++ b/src/main/java/com/ripple/BE/member/domain/type/LoginType.java
@@ -1,5 +1,6 @@
 package com.ripple.BE.member.domain.type;
 
 public enum LoginType {
-	BASIC, KAKAO
+    BASIC,
+    KAKAO
 }

--- a/src/main/java/com/ripple/BE/member/domain/type/Role.java
+++ b/src/main/java/com/ripple/BE/member/domain/type/Role.java
@@ -1,5 +1,6 @@
 package com.ripple.BE.member.domain.type;
 
 public enum Role {
-	USER, ADMIN
+    USER,
+    ADMIN
 }

--- a/src/main/java/com/ripple/BE/news/domain/News.java
+++ b/src/main/java/com/ripple/BE/news/domain/News.java
@@ -1,0 +1,53 @@
+package com.ripple.BE.news.domain;
+
+import com.ripple.BE.global.entity.BaseEntity;
+import com.ripple.BE.image.domain.Image;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "news")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class News extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Size(min = 2, max = 50)
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "publisher")
+    private String publisher; // 출판사
+
+    @OneToMany(mappedBy = "news", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<NewsTerm> newsTermList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "news", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<NewsCategory> newsCategoryList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "news", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Image> imageList = new ArrayList<>();
+}

--- a/src/main/java/com/ripple/BE/news/domain/NewsCategory.java
+++ b/src/main/java/com/ripple/BE/news/domain/NewsCategory.java
@@ -1,0 +1,40 @@
+package com.ripple.BE.news.domain;
+
+import com.ripple.BE.category.domain.Category;
+import com.ripple.BE.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "news_categories")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class NewsCategory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_id")
+    private News news;
+}

--- a/src/main/java/com/ripple/BE/news/domain/NewsScrap.java
+++ b/src/main/java/com/ripple/BE/news/domain/NewsScrap.java
@@ -1,0 +1,40 @@
+package com.ripple.BE.news.domain;
+
+import com.ripple.BE.global.entity.BaseEntity;
+import com.ripple.BE.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "news_scraps")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class NewsScrap extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_id")
+    private News news;
+}

--- a/src/main/java/com/ripple/BE/news/domain/NewsTerm.java
+++ b/src/main/java/com/ripple/BE/news/domain/NewsTerm.java
@@ -1,0 +1,46 @@
+package com.ripple.BE.news.domain;
+
+import com.ripple.BE.global.entity.BaseEntity;
+import com.ripple.BE.term.domain.Term;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "news_term")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class NewsTerm extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "term_id")
+    private Term term;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_id")
+    private News news;
+
+    @Column(name = "start_position", nullable = false)
+    private int startPosition; // 용어의 뉴스 내 시작 위치, 0부터 시작
+
+    @Column(name = "end_position", nullable = false)
+    private int endPosition; // 용어의 뉴스 내 끝 위치, 뉴스 길이보다 작아야 함
+}

--- a/src/main/java/com/ripple/BE/post/domain/Comment.java
+++ b/src/main/java/com/ripple/BE/post/domain/Comment.java
@@ -1,0 +1,59 @@
+package com.ripple.BE.post.domain;
+
+import com.ripple.BE.global.entity.BaseEntity;
+import com.ripple.BE.member.domain.Member;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "comments")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Size(min = 1, max = 255)
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "like_count")
+    private long likeCount = 0L; // 좋아요 수
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member commenter; // 댓글 작성자
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent; // 상위 댓글
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> children = new ArrayList<>(); // 하위 댓글
+}

--- a/src/main/java/com/ripple/BE/post/domain/Post.java
+++ b/src/main/java/com/ripple/BE/post/domain/Post.java
@@ -1,0 +1,69 @@
+package com.ripple.BE.post.domain;
+
+import com.ripple.BE.global.entity.BaseEntity;
+import com.ripple.BE.image.domain.Image;
+import com.ripple.BE.member.domain.Member;
+import com.ripple.BE.post.domain.type.PostType;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "posts")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Size(min = 2, max = 50)
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member author; // 작성자
+
+    @Size(min = 2, max = 500)
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "like_count")
+    private long likeCount = 0L; // 좋아요 수
+
+    @Column(name = "comment_count")
+    private long commentCount = 0L; // 댓글 수
+
+    @Column(name = "post_type", nullable = false)
+    private PostType type; // 게시글 타입
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> commentList = new ArrayList<>(); // 댓글 목록
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostCategory> postCategoryList = new ArrayList<>(); // 게시글 카테고리 목록
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Image> imageList = new ArrayList<>();
+}

--- a/src/main/java/com/ripple/BE/post/domain/PostCategory.java
+++ b/src/main/java/com/ripple/BE/post/domain/PostCategory.java
@@ -1,0 +1,40 @@
+package com.ripple.BE.post.domain;
+
+import com.ripple.BE.category.domain.Category;
+import com.ripple.BE.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "post_categories")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PostCategory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+}

--- a/src/main/java/com/ripple/BE/post/domain/PostLike.java
+++ b/src/main/java/com/ripple/BE/post/domain/PostLike.java
@@ -1,0 +1,40 @@
+package com.ripple.BE.post.domain;
+
+import com.ripple.BE.global.entity.BaseEntity;
+import com.ripple.BE.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "post_likes")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PostLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+}

--- a/src/main/java/com/ripple/BE/post/domain/PostScrap.java
+++ b/src/main/java/com/ripple/BE/post/domain/PostScrap.java
@@ -1,0 +1,40 @@
+package com.ripple.BE.post.domain;
+
+import com.ripple.BE.global.entity.BaseEntity;
+import com.ripple.BE.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "post_scraps")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PostScrap extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+}

--- a/src/main/java/com/ripple/BE/post/domain/type/PostType.java
+++ b/src/main/java/com/ripple/BE/post/domain/type/PostType.java
@@ -1,0 +1,17 @@
+package com.ripple.BE.post.domain.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PostType {
+    ECONOMY_TALK("경제 톡톡"),
+    FREE("자유"),
+    QUESTION("질문"),
+    ECONOMY_STUDY_TIP("경제 공부 tip"),
+    EVENT_NEWS("이벤트/소식"),
+    BOOK_RECOMMENDATION("도서 추천");
+
+    private final String postType;
+}

--- a/src/main/java/com/ripple/BE/term/domain/Term.java
+++ b/src/main/java/com/ripple/BE/term/domain/Term.java
@@ -1,0 +1,41 @@
+package com.ripple.BE.term.domain;
+
+import com.ripple.BE.global.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "terms")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Term extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @OneToMany(mappedBy = "term", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TermCategory> termCategoryList = new ArrayList<>();
+}

--- a/src/main/java/com/ripple/BE/term/domain/TermCategory.java
+++ b/src/main/java/com/ripple/BE/term/domain/TermCategory.java
@@ -1,0 +1,40 @@
+package com.ripple.BE.term.domain;
+
+import com.ripple.BE.category.domain.Category;
+import com.ripple.BE.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "term_categories")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class TermCategory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "term_id")
+    private Term term;
+}

--- a/src/main/java/com/ripple/BE/term/domain/TermScrap.java
+++ b/src/main/java/com/ripple/BE/term/domain/TermScrap.java
@@ -1,0 +1,40 @@
+package com.ripple.BE.term.domain;
+
+import com.ripple.BE.global.entity.BaseEntity;
+import com.ripple.BE.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "term_scraps")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class TermScrap extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "term_id")
+    private Term term;
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,7 +11,7 @@ spring:
   jpa:
     database: mysql
     database-platform: org.hibernate.dialect.MySQLDialect
-    show-sql: false
+    show-sql: true
     hibernate:
       ddl-auto: update
     properties:


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #6 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- Post, News, Term, Category 등은 ERD에 따라 속성 필드 추가
- 스크랩, 좋아요, 카테고리 등에 다대다 관계 매핑 정보를 관리하기 위해 NewsScrap, NewsCategory PostScrap, PostLike, TermScrap 등의 중간 테이블을 추가
     - 카테고리를 제외한 중간 테이블 정보들은 마이페이지에서 접근하는 정보들이기 때문에 Member Table에서만 접근할 수 있는 단방향 관계로 구현하였습니다. 
     - <img width="500" alt="image" src="https://github.com/user-attachments/assets/cf0c4c1e-2cd6-475f-b6c6-c4c2f5683788">

- Comment의 대댓글 달기 기능 구현을 위해 자기 참조 필드 추가
     - <img width="433" alt="image" src="https://github.com/user-attachments/assets/8cb53306-0462-471b-a50b-3621e6b37deb">
 
- 빌드 후 테이블 생성 확인 완료



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 전체적으로 검토는 했는데 빠진 속성이나 연관관계 매핑들이 있는지 확인해주세요!
> 코드 작성으로 수정된 필드들은 ERD에 반영해놓겠습니다!