### PR TITLE
Feat : 이미지 추가 및 삭제 api 구현, 게시물 작성 및 수정 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,8 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-
+    // amazon s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 clean {	delete file('src/main/generated')}

--- a/src/main/java/com/ripple/BE/global/config/S3Config.java
+++ b/src/main/java/com/ripple/BE/global/config/S3Config.java
@@ -1,0 +1,34 @@
+package com.ripple.BE.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@NoArgsConstructor
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client)
+                AmazonS3ClientBuilder.standard()
+                        .withRegion(region)
+                        .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                        .build();
+    }
+}

--- a/src/main/java/com/ripple/BE/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/ripple/BE/global/exception/handler/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.ripple.BE.global.exception.errorcode.GlobalErrorCode;
 import com.ripple.BE.global.exception.response.ErrorResponse;
 import com.ripple.BE.global.exception.response.ErrorResponse.ValidationError;
 import com.ripple.BE.global.exception.response.ErrorResponse.ValidationErrors;
+import com.ripple.BE.image.exception.ImageException;
 import com.ripple.BE.learning.exception.LearningException;
 import com.ripple.BE.learning.exception.QuizException;
 import com.ripple.BE.post.exception.PostException;
@@ -83,6 +84,11 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(PostException.class)
     public ResponseEntity<Object> handlePostException(final PostException e) {
+        return handleExceptionInternal(e.getErrorCode());
+    }
+
+    @ExceptionHandler(ImageException.class)
+    public ResponseEntity<Object> handleImageException(final ImageException e) {
         return handleExceptionInternal(e.getErrorCode());
     }
 

--- a/src/main/java/com/ripple/BE/image/controller/ImageController.java
+++ b/src/main/java/com/ripple/BE/image/controller/ImageController.java
@@ -39,7 +39,7 @@ public class ImageController {
     public ResponseEntity<ApiResponse<Object>> deleteImage(
             final @PathVariable("imageId") long imageId) {
 
-        imageService.deleteImageFromPost(imageId);
+        imageService.deleteImage(imageId);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(ApiResponse.EMPTY_RESPONSE));
     }
 }

--- a/src/main/java/com/ripple/BE/image/controller/ImageController.java
+++ b/src/main/java/com/ripple/BE/image/controller/ImageController.java
@@ -1,0 +1,45 @@
+package com.ripple.BE.image.controller;
+
+import com.ripple.BE.global.dto.response.ApiResponse;
+import com.ripple.BE.image.dto.response.ImageIdResponse;
+import com.ripple.BE.image.service.ImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/image")
+@Tag(name = "Image", description = "이미지 API")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @Operation(summary = "게시물 단일 사진 추가", description = "게시물을 등록하기 전 단일 사진을 추가합니다.")
+    @PostMapping(consumes = "multipart/form-data")
+    public ResponseEntity<ApiResponse<Object>> createPost(final @RequestParam MultipartFile file) {
+
+        long imageId = imageService.addImageToPost(file);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.from(ImageIdResponse.toImageIdResponse(imageId)));
+    }
+
+    @Operation(summary = "게시물 사진 삭제", description = "게시물에 등록된 사진을 삭제합니다.")
+    @DeleteMapping("/{imageId}")
+    public ResponseEntity<ApiResponse<Object>> deleteImage(
+            final @PathVariable("imageId") long imageId) {
+
+        imageService.deleteImageFromPost(imageId);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(ApiResponse.EMPTY_RESPONSE));
+    }
+}

--- a/src/main/java/com/ripple/BE/image/domain/Image.java
+++ b/src/main/java/com/ripple/BE/image/domain/Image.java
@@ -17,6 +17,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Table(name = "images")
 @Getter
@@ -31,8 +32,10 @@ public class Image extends BaseEntity {
     @Column(name = "id")
     private Long id;
 
-    private String imageUrl;
+    @Column(name = "s3_info")
+    private S3Info s3Info;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
@@ -40,4 +43,8 @@ public class Image extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "news_id")
     private News news;
+
+    public static Image toImageEntity(final S3Info s3Info) {
+        return Image.builder().s3Info(s3Info).build();
+    }
 }

--- a/src/main/java/com/ripple/BE/image/domain/S3Info.java
+++ b/src/main/java/com/ripple/BE/image/domain/S3Info.java
@@ -1,0 +1,19 @@
+package com.ripple.BE.image.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class S3Info {
+    private String folderName;
+    private String fileName;
+    private String url;
+}

--- a/src/main/java/com/ripple/BE/image/dto/ImageDTO.java
+++ b/src/main/java/com/ripple/BE/image/dto/ImageDTO.java
@@ -2,13 +2,13 @@ package com.ripple.BE.image.dto;
 
 import com.ripple.BE.image.domain.Image;
 
-public record ImageDTO(String url) {
+public record ImageDTO(Long id, String url) {
 
     public static ImageDTO toImageDTO(final Image image) {
-        return new ImageDTO(image.getImageUrl());
+        return new ImageDTO(image.getId(), image.getS3Info().getUrl());
     }
 
     public static ImageDTO toImageDTO(final String imageUrl) {
-        return new ImageDTO(imageUrl);
+        return new ImageDTO(null, imageUrl);
     }
 }

--- a/src/main/java/com/ripple/BE/image/dto/response/ImageIdResponse.java
+++ b/src/main/java/com/ripple/BE/image/dto/response/ImageIdResponse.java
@@ -1,0 +1,7 @@
+package com.ripple.BE.image.dto.response;
+
+public record ImageIdResponse(Long imageId) {
+    public static ImageIdResponse toImageIdResponse(long imageId) {
+        return new ImageIdResponse(imageId);
+    }
+}

--- a/src/main/java/com/ripple/BE/image/dto/response/ImageResponse.java
+++ b/src/main/java/com/ripple/BE/image/dto/response/ImageResponse.java
@@ -1,0 +1,14 @@
+package com.ripple.BE.image.dto.response;
+
+import com.ripple.BE.image.dto.ImageDTO;
+
+public record ImageResponse(Long id, String url) {
+
+    public static ImageResponse toImageResponse(final Long id, final String url) {
+        return new ImageResponse(id, url);
+    }
+
+    public static ImageResponse toImageResponse(final ImageDTO imageDTO) {
+        return new ImageResponse(imageDTO.id(), imageDTO.url());
+    }
+}

--- a/src/main/java/com/ripple/BE/image/exception/ImageException.java
+++ b/src/main/java/com/ripple/BE/image/exception/ImageException.java
@@ -1,0 +1,12 @@
+package com.ripple.BE.image.exception;
+
+import com.ripple.BE.global.exception.errorcode.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ImageException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/ripple/BE/image/exception/errorcode/ImageErrorCode.java
+++ b/src/main/java/com/ripple/BE/image/exception/errorcode/ImageErrorCode.java
@@ -1,0 +1,16 @@
+package com.ripple.BE.image.exception.errorcode;
+
+import com.ripple.BE.global.exception.errorcode.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageErrorCode implements ErrorCode {
+    IMAGE_PROCESSING_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "Image processing fail"),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "Image not found");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/ripple/BE/image/repository/ImageRepository.java
+++ b/src/main/java/com/ripple/BE/image/repository/ImageRepository.java
@@ -1,0 +1,8 @@
+package com.ripple.BE.image.repository;
+
+import com.ripple.BE.image.domain.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ImageRepository extends JpaRepository<Image, Long> {}

--- a/src/main/java/com/ripple/BE/image/s3/S3Uploader.java
+++ b/src/main/java/com/ripple/BE/image/s3/S3Uploader.java
@@ -38,7 +38,6 @@ public class S3Uploader {
         String fileName = buildFileName(folderName, file.getName());
         String uploadUrl = uploadToS3(file, fileName);
 
-        System.out.println("uploadUrl: " + uploadUrl);
         file.delete();
 
         return buildS3Info(folderName, file, uploadUrl);
@@ -66,9 +65,6 @@ public class S3Uploader {
         String fileExtension = getFileExtension(file);
         File convertedFile =
                 new File(System.getProperty("user.dir") + "/" + UUID.randomUUID() + "." + fileExtension);
-
-        System.out.println("convertedFile: " + convertedFile.getName());
-        System.out.println("convertedFile: " + convertedFile.getAbsolutePath());
 
         try (FileOutputStream fos = new FileOutputStream(convertedFile)) {
             fos.write(file.getBytes());

--- a/src/main/java/com/ripple/BE/image/s3/S3Uploader.java
+++ b/src/main/java/com/ripple/BE/image/s3/S3Uploader.java
@@ -1,0 +1,97 @@
+package com.ripple.BE.image.s3;
+
+import static com.ripple.BE.image.exception.errorcode.ImageErrorCode.*;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.ripple.BE.image.domain.S3Info;
+import com.ripple.BE.image.exception.ImageException;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class S3Uploader {
+
+    private static final String CONTENT_TYPE = "multipart/formed-data";
+    private final AmazonS3Client amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public S3Info uploadFiles(MultipartFile multipartFile, String folderName) throws ImageException {
+        File localUploadFile = convertToFile(multipartFile);
+        return uploadFileToS3(localUploadFile, folderName);
+    }
+
+    public S3Info uploadFileToS3(File file, String folderName) {
+        String fileName = buildFileName(folderName, file.getName());
+        String uploadUrl = uploadToS3(file, fileName);
+
+        System.out.println("uploadUrl: " + uploadUrl);
+        file.delete();
+
+        return buildS3Info(folderName, file, uploadUrl);
+    }
+
+    public void deleteFile(S3Info s3Info) {
+        String fileName = buildFileName(s3Info.getFolderName(), s3Info.getFileName());
+        log.info("{} 사진 삭제", fileName);
+        amazonS3.deleteObject(bucket, fileName);
+    }
+
+    private String uploadToS3(File uploadFile, String fileName) {
+        PutObjectRequest putObjectRequest =
+                new PutObjectRequest(bucket, fileName, uploadFile)
+                        .withCannedAcl(CannedAccessControlList.PublicRead);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(CONTENT_TYPE);
+        amazonS3.putObject(putObjectRequest);
+
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+
+    private static File convertToFile(MultipartFile file) throws ImageException {
+        String fileExtension = getFileExtension(file);
+        File convertedFile =
+                new File(System.getProperty("user.dir") + "/" + UUID.randomUUID() + "." + fileExtension);
+
+        System.out.println("convertedFile: " + convertedFile.getName());
+        System.out.println("convertedFile: " + convertedFile.getAbsolutePath());
+
+        try (FileOutputStream fos = new FileOutputStream(convertedFile)) {
+            fos.write(file.getBytes());
+        } catch (IOException e) {
+            throw new ImageException(IMAGE_PROCESSING_FAIL);
+        }
+
+        return convertedFile;
+    }
+
+    private static String getFileExtension(MultipartFile file) throws ImageException {
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || !originalFilename.contains(".")) {
+            throw new ImageException(IMAGE_NOT_FOUND);
+        }
+        return originalFilename.substring(originalFilename.lastIndexOf(".") + 1);
+    }
+
+    private String buildFileName(String folderName, String fileName) {
+        return folderName + "/" + fileName;
+    }
+
+    private S3Info buildS3Info(String folderName, File file, String uploadUrl) {
+        return S3Info.builder().folderName(folderName).fileName(file.getName()).url(uploadUrl).build();
+    }
+}

--- a/src/main/java/com/ripple/BE/image/service/ImageService.java
+++ b/src/main/java/com/ripple/BE/image/service/ImageService.java
@@ -1,0 +1,43 @@
+package com.ripple.BE.image.service;
+
+import static com.ripple.BE.image.exception.errorcode.ImageErrorCode.*;
+
+import com.ripple.BE.image.domain.Image;
+import com.ripple.BE.image.domain.S3Info;
+import com.ripple.BE.image.exception.ImageException;
+import com.ripple.BE.image.repository.ImageRepository;
+import com.ripple.BE.image.s3.S3Uploader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class ImageService {
+
+    private final ImageRepository imageRepository;
+    private final S3Uploader s3Uploader;
+
+    private static final String FOLDER_NAME = "post";
+
+    @Transactional
+    public long addImageToPost(MultipartFile file) {
+
+        S3Info s3Info = s3Uploader.uploadFiles(file, FOLDER_NAME);
+
+        Image image = imageRepository.save(Image.toImageEntity(s3Info));
+        return image.getId();
+    }
+
+    @Transactional
+    public void deleteImageFromPost(long imageId) {
+        Image image =
+                imageRepository.findById(imageId).orElseThrow(() -> new ImageException(IMAGE_NOT_FOUND));
+        s3Uploader.deleteFile(image.getS3Info());
+
+        imageRepository.delete(image);
+    }
+}

--- a/src/main/java/com/ripple/BE/image/service/ImageService.java
+++ b/src/main/java/com/ripple/BE/image/service/ImageService.java
@@ -33,7 +33,7 @@ public class ImageService {
     }
 
     @Transactional
-    public void deleteImageFromPost(long imageId) {
+    public void deleteImage(long imageId) {
         Image image =
                 imageRepository.findById(imageId).orElseThrow(() -> new ImageException(IMAGE_NOT_FOUND));
         s3Uploader.deleteFile(image.getS3Info());

--- a/src/main/java/com/ripple/BE/post/controller/PostController.java
+++ b/src/main/java/com/ripple/BE/post/controller/PostController.java
@@ -7,6 +7,7 @@ import com.ripple.BE.post.dto.PostDTO;
 import com.ripple.BE.post.dto.PostListDTO;
 import com.ripple.BE.post.dto.request.CommentRequest;
 import com.ripple.BE.post.dto.request.PostRequest;
+import com.ripple.BE.post.dto.request.PostUpdateRequest;
 import com.ripple.BE.post.dto.response.PostListResponse;
 import com.ripple.BE.post.dto.response.PostResponse;
 import com.ripple.BE.post.service.PostService;
@@ -15,7 +16,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.PositiveOrZero;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -31,7 +31,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @RestController
@@ -41,17 +40,33 @@ public class PostController {
 
     private final PostService postService;
 
-    @Operation(summary = "게시물 작성", description = "게시물을 작성합니다.")
+    @Operation(summary = "게시물 작성", description = "게시물을 작성합니다. 게시물을 등록하기 전 이미지 등록을 완료해주세요")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Object>> createPost(
             final @AuthenticationPrincipal CustomUserDetails currentUser,
-            final @RequestPart(value = "post") @Valid PostRequest post,
-            final @RequestPart(value = "imageList", required = false) List<MultipartFile> imageList) {
+            final @RequestPart(value = "post") @Valid PostRequest request) {
 
-        postService.createPost(currentUser.getId(), PostDTO.toPostDTO(post), imageList);
+        postService.createPost(
+                currentUser.getId(), PostDTO.toPostDTO(request), request.type(), request.imageIds());
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.from(ApiResponse.EMPTY_RESPONSE));
+    }
+
+    @Operation(
+            summary = "게시물 수정",
+            description =
+                    "게시물을 수정합니다. 게시물을 수정하기 전 이미지 수정을 완료해주세요. 삭제한 이미지는 입력하지 말고, 새로 추가된 이미지의 ID만 입력해주세요.")
+    @PatchMapping("/{id}")
+    public ResponseEntity<ApiResponse<Object>> updatePost(
+            final @AuthenticationPrincipal CustomUserDetails currentUser,
+            final @PathVariable("id") long id,
+            final @Valid @RequestBody PostUpdateRequest request) {
+
+        postService.updatePost(
+                id, currentUser.getId(), PostDTO.toPostDTO(request), request.newImageIds());
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(ApiResponse.EMPTY_RESPONSE));
     }
 
     @Operation(summary = "게시물 삭제", description = "게시물을 삭제합니다.")

--- a/src/main/java/com/ripple/BE/post/domain/Post.java
+++ b/src/main/java/com/ripple/BE/post/domain/Post.java
@@ -63,6 +63,7 @@ public class Post extends BaseEntity {
     @Column(name = "scrap_count")
     private long scrapCount = 0L; // 스크랩 수
 
+    @Setter
     @Column(name = "post_type", nullable = false)
     private PostType type; // 게시글 타입
 
@@ -114,11 +115,23 @@ public class Post extends BaseEntity {
                 .title(postDTO.title())
                 .content(postDTO.content())
                 .type(postDTO.type())
+                .imageList(new ArrayList<>())
                 .build();
+    }
+
+    public void update(PostDTO postDTO) {
+        this.title = postDTO.title();
+        this.content = postDTO.content();
+        this.type = postDTO.type();
     }
 
     public void setAuthor(User author) {
         this.author = author;
         author.getPostList().add(this);
+    }
+
+    public void addImage(Image image) {
+        this.imageList.add(image);
+        image.setPost(this);
     }
 }

--- a/src/main/java/com/ripple/BE/post/dto/PostDTO.java
+++ b/src/main/java/com/ripple/BE/post/dto/PostDTO.java
@@ -4,6 +4,7 @@ import com.ripple.BE.image.dto.ImageListDTO;
 import com.ripple.BE.post.domain.Post;
 import com.ripple.BE.post.domain.type.PostType;
 import com.ripple.BE.post.dto.request.PostRequest;
+import com.ripple.BE.post.dto.request.PostUpdateRequest;
 import com.ripple.BE.user.dto.CommunityUserDTO;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -64,6 +65,23 @@ public record PostDTO(
                 null,
                 postRequest.content(),
                 postRequest.type(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    public static PostDTO toPostDTO(final PostUpdateRequest request) {
+        return new PostDTO(
+                null,
+                request.title(),
+                null,
+                request.content(),
+                request.type(),
                 null,
                 null,
                 null,

--- a/src/main/java/com/ripple/BE/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/ripple/BE/post/dto/request/PostUpdateRequest.java
@@ -5,8 +5,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
-public record PostRequest(
+public record PostUpdateRequest(
         @NotNull @Size(min = 2, max = 50) String title,
         @Size(min = 2, max = 3500) String content,
         PostType type,
-        List<Long> imageIds) {}
+        List<Long> newImageIds) {}

--- a/src/main/java/com/ripple/BE/post/dto/response/PostResponse.java
+++ b/src/main/java/com/ripple/BE/post/dto/response/PostResponse.java
@@ -1,7 +1,7 @@
 package com.ripple.BE.post.dto.response;
 
 import com.ripple.BE.global.utils.RelativeTimeFormatter;
-import com.ripple.BE.image.dto.ImageDTO;
+import com.ripple.BE.image.dto.response.ImageResponse;
 import com.ripple.BE.post.domain.type.PostType;
 import com.ripple.BE.post.dto.PostDTO;
 import java.util.List;
@@ -16,7 +16,7 @@ public record PostResponse(
         long likeCount,
         long commentCount,
         long scrapCount,
-        List<String> imageList,
+        List<ImageResponse> imageList,
         String createdDate,
         CommentListResponse commentListResponse) {
 
@@ -31,7 +31,7 @@ public record PostResponse(
                 postDTO.likeCount(),
                 postDTO.commentCount(),
                 postDTO.scrapCount(),
-                postDTO.imageList().imageDTOList().stream().map(ImageDTO::url).toList(),
+                postDTO.imageList().imageDTOList().stream().map(ImageResponse::toImageResponse).toList(),
                 RelativeTimeFormatter.formatRelativeTime(postDTO.createdDate()),
                 CommentListResponse.toCommentListResponse(postDTO.commentListDTO()));
     }

--- a/src/main/java/com/ripple/BE/post/service/PostService.java
+++ b/src/main/java/com/ripple/BE/post/service/PostService.java
@@ -1,7 +1,12 @@
 package com.ripple.BE.post.service;
 
+import static com.ripple.BE.image.exception.errorcode.ImageErrorCode.*;
 import static com.ripple.BE.post.exception.errorcode.PostErrorCode.*;
 
+import com.ripple.BE.image.domain.Image;
+import com.ripple.BE.image.exception.ImageException;
+import com.ripple.BE.image.repository.ImageRepository;
+import com.ripple.BE.image.service.ImageService;
 import com.ripple.BE.post.domain.Comment;
 import com.ripple.BE.post.domain.CommentLike;
 import com.ripple.BE.post.domain.Post;
@@ -28,7 +33,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
@@ -40,21 +44,62 @@ public class PostService {
     private final PostLikeRepository postLikeRepository;
     private final PostScrapRepository postScrapRepository;
     private final CommentLikeRepository commentLikeRepository;
+    private final ImageRepository imageRepository;
 
     private final UserService userService;
+    private final ImageService imageService;
 
     private static final int PAGE_SIZE = 10;
 
     @Transactional
     public void createPost(
-            final long userId, final PostDTO postDTO, final List<MultipartFile> imageList) {
+            final long userId,
+            final PostDTO postDTO,
+            final PostType postType,
+            final List<Long> imageIdList) {
         User user = userService.findUserById(userId);
 
         Post post = Post.toPostEntity(postDTO);
         post.setAuthor(user);
+        post.setType(postType);
 
-        /** 이미지 S3 업로드 로직 추후 추가 */
+        if (imageIdList != null && !imageIdList.isEmpty()) {
+            for (long imageId : imageIdList) {
+                Image image =
+                        imageRepository
+                                .findById(imageId)
+                                .orElseThrow(() -> new ImageException(IMAGE_NOT_FOUND));
+                post.addImage(image);
+            }
+        }
+
         postRepository.save(post);
+    }
+
+    @Transactional
+    public void updatePost(
+            final long postId,
+            final long userId,
+            final PostDTO postDTO,
+            final List<Long> newImageIdList) {
+
+        Post post = findPostById(postId);
+
+        if (post.getAuthor().getId() != userId) {
+            throw new PostException(POST_NOT_AUTHORIZED);
+        }
+
+        post.update(postDTO);
+
+        if (newImageIdList != null && !newImageIdList.isEmpty()) {
+            for (long imageId : newImageIdList) {
+                Image image =
+                        imageRepository
+                                .findById(imageId)
+                                .orElseThrow(() -> new ImageException(IMAGE_NOT_FOUND));
+                post.addImage(image);
+            }
+        }
     }
 
     @Transactional
@@ -63,6 +108,10 @@ public class PostService {
 
         if (post.getAuthor().getId() != userId) {
             throw new PostException(POST_NOT_AUTHORIZED);
+        }
+
+        for (Image image : post.getImageList()) {
+            imageService.deleteImageFromPost(image.getId());
         }
 
         postRepository.delete(post);

--- a/src/main/java/com/ripple/BE/post/service/PostService.java
+++ b/src/main/java/com/ripple/BE/post/service/PostService.java
@@ -111,7 +111,7 @@ public class PostService {
         }
 
         for (Image image : post.getImageList()) {
-            imageService.deleteImageFromPost(image.getId());
+            imageService.deleteImage(image.getId());
         }
 
         postRepository.delete(post);

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -21,6 +21,20 @@ spring:
     redis:
       host: localhost
       port: 6379
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
+cloud:
+  aws:
+    s3:
+      bucket: ${BUCKET_ADDRESS}
+    stack.auto: false
+    region.static: ap-northeast-2
+    credentials:
+      accessKey: ${S3_ACCESS_KEY}
+      secretKey: ${S3_ACCESS_PASSWORD}
 
 logging:
   level:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -21,6 +21,20 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
+cloud:
+  aws:
+    s3:
+      bucket: ${BUCKET_ADDRESS}
+    stack.auto: false
+    region.static: ap-northeast-2
+    credentials:
+      accessKey: ${S3_ACCESS_KEY}
+      secretKey: ${S3_ACCESS_PASSWORD}
 
 server:
   ssl:


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #27 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

###  S3 설정
### 이미지 추가 및 삭제 api 구현  
<img width="1090" alt="image" src="https://github.com/user-attachments/assets/a02565a9-4cbf-4d8d-853c-13d6d1948859" />

- 게시물 등록하기 api를 요청하기 전, 이미지 추가 api 실행
- 이미지 추가 api를 실행하면 S3로 이미지를 업로드 하고, imageId 반환
- 반환된 이미지 id들은 추후, 게시물 작성 api의 입력값으로 사용되어야 함

### 게시물 작성 api 구현
<img width="389" alt="image" src="https://github.com/user-attachments/assets/9aa6386e-3a47-41be-a251-4fdb9b6144a2" />

- 제목, 내용, 타입, 이미지 id 목록을 입력을 받아서 게시물 작성

### 게시물 수정 api 구현

<img width="233" alt="image" src="https://github.com/user-attachments/assets/cd942c46-907a-4be1-b375-3b0dcfce1a83" />


- 이 api를 호출하기 전에 사진 수정이 필요할 경우, 필요하지 않은 사진은 삭제 api를 통해서 삭제, 추가할 사진은 이미지 추가 api를 통해서 추가
- 입력으로 넘겨줘야 할 imageId에는 새로 추가한 이미지의 id만 넘겨주면 됨




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?