### PR TITLE
Feat : 마이페이지 기능을 위한 저장기능을 구현한다

### DIFF
--- a/src/main/java/com/ripple/BE/learning/controller/ConceptController.java
+++ b/src/main/java/com/ripple/BE/learning/controller/ConceptController.java
@@ -49,4 +49,14 @@ public class ConceptController {
         conceptService.completeConceptLearning(currentUser.getId(), learningSetId, level);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
     }
+
+    @Operation(summary = "개념 학습 저장", description = "개념 학습을 저장합니다.")
+    @PostMapping("/learning/{conceptId}/scrap")
+    public ResponseEntity<ApiResponse<?>> scrapConcept(
+            final @AuthenticationPrincipal CustomUserDetails currentUser,
+            final @PathVariable("conceptId") long conceptId) {
+
+        conceptService.scrapConcept(currentUser.getId(), conceptId);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
+    }
 }

--- a/src/main/java/com/ripple/BE/learning/controller/QuizController.java
+++ b/src/main/java/com/ripple/BE/learning/controller/QuizController.java
@@ -1,10 +1,12 @@
 package com.ripple.BE.learning.controller;
 
 import com.ripple.BE.global.dto.response.ApiResponse;
+import com.ripple.BE.learning.dto.QuizDTO;
 import com.ripple.BE.learning.dto.QuizListDTO;
 import com.ripple.BE.learning.dto.QuizResultDTO;
 import com.ripple.BE.learning.dto.request.SubmitAnswerRequest;
 import com.ripple.BE.learning.dto.response.QuizListResponse;
+import com.ripple.BE.learning.dto.response.QuizResponse;
 import com.ripple.BE.learning.dto.response.QuizResultResponse;
 import com.ripple.BE.learning.service.quiz.QuizService;
 import com.ripple.BE.user.domain.CustomUserDetails;
@@ -16,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -79,5 +82,16 @@ public class QuizController {
 
         quizService.scrapQuiz(currentUser.getId(), conceptId);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
+    }
+
+    @Operation(summary = "개별 퀴즈 조회", description = "개별 퀴즈를 조회합니다.")
+    @GetMapping("/learning/quiz/{quizId}")
+    public ResponseEntity<ApiResponse<Object>> getSingleQuiz(
+            final @PathVariable("quizId") long quizId) {
+
+        QuizDTO quizDTO = quizService.getSingleQuiz(quizId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.from(QuizResponse.toQuizResponse(quizDTO)));
     }
 }

--- a/src/main/java/com/ripple/BE/learning/controller/QuizController.java
+++ b/src/main/java/com/ripple/BE/learning/controller/QuizController.java
@@ -70,4 +70,14 @@ public class QuizController {
 
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(ApiResponse.EMPTY_RESPONSE));
     }
+
+    @Operation(summary = "퀴즈 저장", description = "퀴즈를 저장합니다.")
+    @PostMapping("/learning/quiz/{quizId}/scrap")
+    public ResponseEntity<ApiResponse<?>> scrapQuiz(
+            final @AuthenticationPrincipal CustomUserDetails currentUser,
+            final @PathVariable("quizId") long conceptId) {
+
+        quizService.scrapQuiz(currentUser.getId(), conceptId);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
+    }
 }

--- a/src/main/java/com/ripple/BE/learning/controller/QuizController.java
+++ b/src/main/java/com/ripple/BE/learning/controller/QuizController.java
@@ -78,9 +78,9 @@ public class QuizController {
     @PostMapping("/learning/quiz/{quizId}/scrap")
     public ResponseEntity<ApiResponse<?>> scrapQuiz(
             final @AuthenticationPrincipal CustomUserDetails currentUser,
-            final @PathVariable("quizId") long conceptId) {
+            final @PathVariable("quizId") long quizId) {
 
-        quizService.scrapQuiz(currentUser.getId(), conceptId);
+        quizService.scrapQuiz(currentUser.getId(), quizId);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
     }
 

--- a/src/main/java/com/ripple/BE/learning/domain/concept/ConceptScrap.java
+++ b/src/main/java/com/ripple/BE/learning/domain/concept/ConceptScrap.java
@@ -1,0 +1,39 @@
+package com.ripple.BE.learning.domain.concept;
+
+import com.ripple.BE.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "concept_scraps")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ConceptScrap {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "concept_id")
+    private Concept concept;
+}

--- a/src/main/java/com/ripple/BE/learning/repository/ConceptScrapRepository.java
+++ b/src/main/java/com/ripple/BE/learning/repository/ConceptScrapRepository.java
@@ -1,0 +1,8 @@
+package com.ripple.BE.learning.repository;
+
+import com.ripple.BE.learning.domain.concept.ConceptScrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConceptScrapRepository extends JpaRepository<ConceptScrap, Long> {}

--- a/src/main/java/com/ripple/BE/learning/repository/QuizScrapRepository.java
+++ b/src/main/java/com/ripple/BE/learning/repository/QuizScrapRepository.java
@@ -1,0 +1,8 @@
+package com.ripple.BE.learning.repository;
+
+import com.ripple.BE.learning.domain.quiz.QuizScrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuizScrapRepository extends JpaRepository<QuizScrap, Long> {}

--- a/src/main/java/com/ripple/BE/learning/service/concept/ConceptService.java
+++ b/src/main/java/com/ripple/BE/learning/service/concept/ConceptService.java
@@ -1,12 +1,14 @@
 package com.ripple.BE.learning.service.concept;
 
 import com.ripple.BE.learning.domain.concept.Concept;
+import com.ripple.BE.learning.domain.concept.ConceptScrap;
 import com.ripple.BE.learning.domain.learningset.LearningSet;
 import com.ripple.BE.learning.domain.learningset.UserLearningSet;
 import com.ripple.BE.learning.dto.ConceptListDTO;
 import com.ripple.BE.learning.exception.LearningException;
 import com.ripple.BE.learning.exception.errorcode.LearningErrorCode;
 import com.ripple.BE.learning.repository.ConceptRepository;
+import com.ripple.BE.learning.repository.ConceptScrapRepository;
 import com.ripple.BE.learning.repository.UserLearningSetRepository;
 import com.ripple.BE.learning.service.learningset.LearningSetService;
 import com.ripple.BE.user.domain.User;
@@ -28,6 +30,7 @@ public class ConceptService {
 
     private final UserLearningSetRepository userLearningSetRepository;
     private final ConceptRepository conceptRepository;
+    private final ConceptScrapRepository conceptScrapRepository;
 
     /**
      * 학습 세트의 개념 목록을 조회
@@ -65,5 +68,22 @@ public class ConceptService {
             userLearningSet.setConceptCompleted();
             userService.updateCompletedCountByLevel(user, level);
         }
+    }
+
+    /**
+     * 개념 스크랩
+     *
+     * @param userId
+     * @param conceptId
+     */
+    @Transactional
+    public void scrapConcept(final long userId, final long conceptId) {
+        User user = userService.findUserById(userId);
+        Concept concept =
+                conceptRepository
+                        .findById(conceptId)
+                        .orElseThrow(() -> new LearningException(LearningErrorCode.CONCEPT_NOT_FOUND));
+
+        conceptScrapRepository.save(ConceptScrap.builder().user(user).concept(concept).build());
     }
 }

--- a/src/main/java/com/ripple/BE/learning/service/quiz/QuizService.java
+++ b/src/main/java/com/ripple/BE/learning/service/quiz/QuizService.java
@@ -6,13 +6,16 @@ import com.ripple.BE.learning.domain.learningset.LearningSet;
 import com.ripple.BE.learning.domain.learningset.UserLearningSet;
 import com.ripple.BE.learning.domain.quiz.FailQuiz;
 import com.ripple.BE.learning.domain.quiz.Quiz;
+import com.ripple.BE.learning.domain.quiz.QuizScrap;
 import com.ripple.BE.learning.domain.type.Type;
 import com.ripple.BE.learning.dto.QuizDTO;
 import com.ripple.BE.learning.dto.QuizListDTO;
 import com.ripple.BE.learning.dto.QuizResultDTO;
 import com.ripple.BE.learning.exception.LearningException;
+import com.ripple.BE.learning.exception.QuizException;
 import com.ripple.BE.learning.exception.errorcode.LearningErrorCode;
 import com.ripple.BE.learning.repository.QuizRepository;
+import com.ripple.BE.learning.repository.QuizScrapRepository;
 import com.ripple.BE.learning.repository.UserLearningSetRepository;
 import com.ripple.BE.learning.service.learningset.LearningSetService;
 import com.ripple.BE.user.domain.User;
@@ -32,6 +35,7 @@ public class QuizService {
 
     private final UserLearningSetRepository userLearningSetRepository;
     private final QuizRepository quizRepository;
+    private final QuizScrapRepository quizScrapRepository;
 
     private final QuizRedisService quizRedisService;
     private final LearningSetService learningSetService;
@@ -147,5 +151,21 @@ public class QuizService {
                 .filter(q -> q.id().equals(quizId))
                 .findFirst()
                 .orElseThrow(() -> new LearningException(QUIZ_PROGRESS_NOT_FOUND));
+    }
+
+    /**
+     * 퀴즈 스크랩
+     *
+     * @param userId
+     * @param quizId
+     */
+    @Transactional
+    public void scrapQuiz(final long userId, final long quizId) {
+
+        User user = userService.findUserById(userId);
+        Quiz quiz =
+                quizRepository.findById(quizId).orElseThrow(() -> new QuizException(QUIZ_NOT_FOUND));
+
+        quizScrapRepository.save(QuizScrap.builder().user(user).quiz(quiz).build());
     }
 }

--- a/src/main/java/com/ripple/BE/learning/service/quiz/QuizService.java
+++ b/src/main/java/com/ripple/BE/learning/service/quiz/QuizService.java
@@ -31,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 @Slf4j
+@Transactional(readOnly = true)
 public class QuizService {
 
     private final UserLearningSetRepository userLearningSetRepository;
@@ -167,5 +168,16 @@ public class QuizService {
                 quizRepository.findById(quizId).orElseThrow(() -> new QuizException(QUIZ_NOT_FOUND));
 
         quizScrapRepository.save(QuizScrap.builder().user(user).quiz(quiz).build());
+    }
+
+    /**
+     * 개별 퀴즈 조회
+     *
+     * @param quizId
+     * @return 퀴즈 목록 반환
+     */
+    public QuizDTO getSingleQuiz(final long quizId) {
+        Quiz quiz = getQuizById(quizId);
+        return QuizDTO.toQuizDTO(quiz);
     }
 }

--- a/src/main/java/com/ripple/BE/learning/service/quiz/QuizService.java
+++ b/src/main/java/com/ripple/BE/learning/service/quiz/QuizService.java
@@ -88,17 +88,17 @@ public class QuizService {
 
         QuizListDTO quizListDTO =
                 quizRedisService.fetchFromRedis(userId, QUESTION_TYPE, QuizListDTO.class);
+
+        // 마이페이지의 저장한 퀴즈에서 다시풀기 진행 시 (퀴즈 진행 redis 데이터가 없을 경우)
         if (quizListDTO == null) {
-            throw new LearningException(QUIZ_PROGRESS_NOT_FOUND);
+            Quiz quiz = getQuizById(quizId);
+            boolean isCorrect = isCorrectAnswer(QuizDTO.toQuizDTO(quiz), answerIndex);
+
+            return QuizResultDTO.toQuizResultDTO(isCorrect, quiz.getExplanation());
         }
 
         QuizDTO quizDTO = getQuizDTO(quizListDTO, quizId); // 퀴즈 정보 가져오기
-
-        boolean isCorrect =
-                quizDTO
-                        .answer()
-                        .trim()
-                        .equals(quizDTO.choiceList().choices().get(answerIndex).content().trim());
+        boolean isCorrect = isCorrectAnswer(quizDTO, answerIndex);
 
         if (!isCorrect) {
             quizRedisService.saveToRedisList(userId, WRONG_ANSWER_TYPE, quizId); // 오답 리스트에 추가
@@ -179,5 +179,13 @@ public class QuizService {
     public QuizDTO getSingleQuiz(final long quizId) {
         Quiz quiz = getQuizById(quizId);
         return QuizDTO.toQuizDTO(quiz);
+    }
+
+    // 정답 여부 확인
+    private boolean isCorrectAnswer(final QuizDTO quizDTO, final int answerIndex) {
+        return quizDTO
+                .answer()
+                .trim()
+                .equals(quizDTO.choiceList().choices().get(answerIndex).content().trim());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #25 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

<img width="939" alt="스크린샷 2025-01-22 오전 3 20 51" src="https://github.com/user-attachments/assets/6d18363e-6431-4d8b-b09c-3d8986da2aa4" />

- 저장한 학습 조회를 위한 학습 저장 기능
- 저장한 퀴즈 조회를 위한 퀴즈 저장 기능

<img width="942" alt="스크린샷 2025-01-22 오전 3 22 29" src="https://github.com/user-attachments/assets/33e8c66c-7533-4af6-82cb-768b2cfdcd45" />

- 저장한 퀴즈를 다시 풀기 위해 개별 퀴즈 조회 구현
- 퀴즈 제출 api에 개별 퀴즈 제출을 위한 로직 추가


## 💬리뷰 요구사항(선택)

> 퀴즈 제출 로직(QuizService)에서 redis에 데이터가 없는 경우 exception발생시키는 부분에 개별 퀴즈 제출 로직을 추가하였는데 괜찮을지 확인부탁드려요

> learning 브랜치에 작업해서 먼저 pr보냅니다