### PR TITLE
[Feat] 검색 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,10 @@ dependencies {
     // amazon s3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+    // JACKSON
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+
 }
 
 clean {	delete file('src/main/generated')}

--- a/src/main/java/com/ripple/BE/RippleApplication.java
+++ b/src/main/java/com/ripple/BE/RippleApplication.java
@@ -2,8 +2,10 @@ package com.ripple.BE;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableCaching
 @EnableScheduling
 @SpringBootApplication
 public class RippleApplication {

--- a/src/main/java/com/ripple/BE/global/config/RedisConfig.java
+++ b/src/main/java/com/ripple/BE/global/config/RedisConfig.java
@@ -1,10 +1,15 @@
 package com.ripple.BE.global.config;
 
+import java.time.Duration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -21,5 +26,24 @@ public class RedisConfig {
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         return template;
+    }
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration configuration =
+                RedisCacheConfiguration.defaultCacheConfig()
+                        .disableCachingNullValues()
+                        .entryTtl(Duration.ofMinutes(1)) // 캐시 만료 시간
+                        .computePrefixWith(CacheKeyPrefix.simple())
+                        .serializeKeysWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new StringRedisSerializer()))
+                        .serializeValuesWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(connectionFactory)
+                .cacheDefaults(configuration)
+                .build();
     }
 }

--- a/src/main/java/com/ripple/BE/global/entity/BaseEntity.java
+++ b/src/main/java/com/ripple/BE/global/entity/BaseEntity.java
@@ -1,5 +1,9 @@
 package com.ripple.BE.global.entity;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
@@ -15,10 +19,14 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
         AuditingEntityListener.class) // JPA 엔티티의 상태 변화를 감지하여 Auditing(자동 필드 값 설정)을 수행하는 리스너를 추가
 public abstract class BaseEntity {
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     @CreatedDate
     @Column(updatable = false, nullable = false)
     private LocalDateTime createdDate;
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     @LastModifiedDate
     @Column(nullable = false)
     private LocalDateTime modifiedDate;

--- a/src/main/java/com/ripple/BE/news/controller/NewsController.java
+++ b/src/main/java/com/ripple/BE/news/controller/NewsController.java
@@ -35,11 +35,12 @@ public class NewsController {
     @Operation(summary = "뉴스 목록 조회", description = "뉴스 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<Object>> getNewsList(
+            final @AuthenticationPrincipal CustomUserDetails currentUser,
             final @RequestParam(required = false, defaultValue = "0") @PositiveOrZero int page,
             final @RequestParam(required = false, defaultValue = "RECENT") NewsSort sort,
             final @RequestParam(required = false) NewsCategory category) {
 
-        NewsListDTO newsListDTO = newsService.getNewsList(page, sort, category);
+        NewsListDTO newsListDTO = newsService.getNewsList(page, sort, category, currentUser.getId());
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.from(NewsListResponse.toNewsListResponse(newsListDTO)));

--- a/src/main/java/com/ripple/BE/news/domain/News.java
+++ b/src/main/java/com/ripple/BE/news/domain/News.java
@@ -14,6 +14,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -21,6 +22,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Table(name = "news")
 @Getter
@@ -56,6 +58,8 @@ public class News extends BaseEntity {
 
     @OneToMany(mappedBy = "news", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Image> imageList = new ArrayList<>();
+
+    @Setter @Transient private Boolean isScrapped;
 
     public static News toNewsEntity(NewsDTO newsDTO) {
         return News.builder()

--- a/src/main/java/com/ripple/BE/news/dto/NewsDTO.java
+++ b/src/main/java/com/ripple/BE/news/dto/NewsDTO.java
@@ -1,5 +1,9 @@
 package com.ripple.BE.news.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.ripple.BE.image.dto.ImageListDTO;
 import com.ripple.BE.news.domain.News;
 import com.ripple.BE.news.domain.type.NewsCategory;
@@ -13,7 +17,9 @@ public record NewsDTO(
         String url,
         Long views,
         NewsCategory category,
-        LocalDateTime createdDate,
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+                @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+                LocalDateTime createdDate,
         ImageListDTO imageList) {
 
     public static NewsDTO toNewsDTO(final News news) {

--- a/src/main/java/com/ripple/BE/news/dto/NewsDTO.java
+++ b/src/main/java/com/ripple/BE/news/dto/NewsDTO.java
@@ -17,6 +17,7 @@ public record NewsDTO(
         String url,
         Long views,
         NewsCategory category,
+        Boolean isScraped,
         @JsonSerialize(using = LocalDateTimeSerializer.class)
                 @JsonDeserialize(using = LocalDateTimeDeserializer.class)
                 LocalDateTime createdDate,
@@ -31,6 +32,7 @@ public record NewsDTO(
                 news.getUrl(),
                 news.getViews(),
                 news.getCategory(),
+                news.getIsScrapped(),
                 news.getCreatedDate(),
                 ImageListDTO.toImageListDTO(news.getImageList()));
     }
@@ -41,6 +43,6 @@ public record NewsDTO(
             final String publisher,
             final String url,
             final NewsCategory category) {
-        return new NewsDTO(null, title, content, publisher, url, null, category, null, null);
+        return new NewsDTO(null, title, content, publisher, url, null, category, null, null, null);
     }
 }

--- a/src/main/java/com/ripple/BE/news/dto/response/NewsListResponse.java
+++ b/src/main/java/com/ripple/BE/news/dto/response/NewsListResponse.java
@@ -3,11 +3,11 @@ package com.ripple.BE.news.dto.response;
 import com.ripple.BE.news.dto.NewsListDTO;
 import java.util.List;
 
-public record NewsListResponse(List<NewsResponse> newsList, int totalPage, int currentPage) {
+public record NewsListResponse(List<NewsPreviewResponse> newsList, int totalPage, int currentPage) {
 
     public static NewsListResponse toNewsListResponse(NewsListDTO newsListDTO) {
         return new NewsListResponse(
-                newsListDTO.newsDTOList().stream().map(NewsResponse::toNewsResponse).toList(),
+                newsListDTO.newsDTOList().stream().map(NewsPreviewResponse::toNewsPreviewResponse).toList(),
                 newsListDTO.totalPage(),
                 newsListDTO.currentPage());
     }

--- a/src/main/java/com/ripple/BE/news/dto/response/NewsPreviewResponse.java
+++ b/src/main/java/com/ripple/BE/news/dto/response/NewsPreviewResponse.java
@@ -1,0 +1,29 @@
+package com.ripple.BE.news.dto.response;
+
+import com.ripple.BE.global.utils.RelativeTimeFormatter;
+import com.ripple.BE.news.dto.NewsDTO;
+
+public record NewsPreviewResponse(
+        Long id,
+        String title,
+        String content,
+        String publisher,
+        long views,
+        String url,
+        String category,
+        Boolean isScraped,
+        String createdDate) {
+
+    public static NewsPreviewResponse toNewsPreviewResponse(NewsDTO newDTO) {
+        return new NewsPreviewResponse(
+                newDTO.id(),
+                newDTO.title(),
+                newDTO.content(),
+                newDTO.publisher(),
+                newDTO.views(),
+                newDTO.url(),
+                newDTO.category().toString(),
+                newDTO.isScraped(),
+                RelativeTimeFormatter.formatRelativeTime(newDTO.createdDate()));
+    }
+}

--- a/src/main/java/com/ripple/BE/news/repository/news/NewsRepositoryCustom.java
+++ b/src/main/java/com/ripple/BE/news/repository/news/NewsRepositoryCustom.java
@@ -8,9 +8,10 @@ import org.springframework.data.domain.Pageable;
 
 public interface NewsRepositoryCustom {
 
-    Page<News> findByCategory(NewsCategory category, NewsSort newsSort, Pageable pageable);
+    Page<News> findByCategory(
+            NewsCategory category, NewsSort newsSort, Pageable pageable, long userId);
 
-    Page<News> findAll(Pageable pageable, NewsSort newsSort);
+    Page<News> findAll(Pageable pageable, NewsSort newsSort, long userId);
 
-    Page<News> searchNews(String keyword, Pageable pageable);
+    Page<News> searchNews(String keyword, Pageable pageable, long userId);
 }

--- a/src/main/java/com/ripple/BE/news/repository/news/NewsRepositoryCustom.java
+++ b/src/main/java/com/ripple/BE/news/repository/news/NewsRepositoryCustom.java
@@ -11,4 +11,6 @@ public interface NewsRepositoryCustom {
     Page<News> findByCategory(NewsCategory category, NewsSort newsSort, Pageable pageable);
 
     Page<News> findAll(Pageable pageable, NewsSort newsSort);
+
+    Page<News> searchNews(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/ripple/BE/news/repository/news/NewsRepositoryCustomImpl.java
+++ b/src/main/java/com/ripple/BE/news/repository/news/NewsRepositoryCustomImpl.java
@@ -31,6 +31,21 @@ public class NewsRepositoryCustomImpl implements NewsRepositoryCustom {
     }
 
     @Override
+    public Page<News> searchNews(String keyword, Pageable pageable) {
+        BooleanExpression predicate = null;
+
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            predicate = news.title.contains(keyword).or(news.content.contains(keyword));
+        }
+
+        List<News> newsList = getNewsByPageable(pageable, predicate, NewsSort.RECENT);
+
+        JPAQuery<Long> countQuery = queryFactory.select(news.count()).from(news).where(predicate);
+
+        return PageableExecutionUtils.getPage(newsList, pageable, countQuery::fetchOne);
+    }
+
+    @Override
     public Page<News> findAll(Pageable pageable, NewsSort newsSort) {
 
         List<News> newsList = getNewsByPageable(pageable, null, newsSort);

--- a/src/main/java/com/ripple/BE/news/repository/news/NewsRepositoryCustomImpl.java
+++ b/src/main/java/com/ripple/BE/news/repository/news/NewsRepositoryCustomImpl.java
@@ -1,11 +1,14 @@
 package com.ripple.BE.news.repository.news;
 
 import static com.ripple.BE.news.domain.QNews.*;
+import static com.ripple.BE.news.domain.QNewsScrap.*;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ripple.BE.news.domain.News;
+import com.ripple.BE.news.domain.QNews;
 import com.ripple.BE.news.domain.type.NewsCategory;
 import com.ripple.BE.news.domain.type.NewsSort;
 import java.util.List;
@@ -20,10 +23,11 @@ public class NewsRepositoryCustomImpl implements NewsRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<News> findByCategory(NewsCategory category, NewsSort newsSort, Pageable pageable) {
+    public Page<News> findByCategory(
+            NewsCategory category, NewsSort newsSort, Pageable pageable, long userId) {
         BooleanExpression predicate = news.category.eq(category);
 
-        List<News> newsList = getNewsByPageable(pageable, predicate, newsSort);
+        List<News> newsList = getNewsWithScrapByPageable(pageable, predicate, newsSort, userId);
 
         JPAQuery<Long> countQuery = queryFactory.select(news.count()).from(news).where(predicate);
 
@@ -31,14 +35,14 @@ public class NewsRepositoryCustomImpl implements NewsRepositoryCustom {
     }
 
     @Override
-    public Page<News> searchNews(String keyword, Pageable pageable) {
+    public Page<News> searchNews(String keyword, Pageable pageable, long userId) {
         BooleanExpression predicate = null;
 
         if (keyword != null && !keyword.trim().isEmpty()) {
             predicate = news.title.contains(keyword).or(news.content.contains(keyword));
         }
 
-        List<News> newsList = getNewsByPageable(pageable, predicate, NewsSort.RECENT);
+        List<News> newsList = getNewsWithScrapByPageable(pageable, predicate, NewsSort.RECENT, userId);
 
         JPAQuery<Long> countQuery = queryFactory.select(news.count()).from(news).where(predicate);
 
@@ -46,36 +50,46 @@ public class NewsRepositoryCustomImpl implements NewsRepositoryCustom {
     }
 
     @Override
-    public Page<News> findAll(Pageable pageable, NewsSort newsSort) {
+    public Page<News> findAll(Pageable pageable, NewsSort newsSort, long userId) {
 
-        List<News> newsList = getNewsByPageable(pageable, null, newsSort);
+        List<News> newsList = getNewsWithScrapByPageable(pageable, null, newsSort, userId);
 
         JPAQuery<Long> countQuery = queryFactory.select(news.count()).from(news);
 
         return PageableExecutionUtils.getPage(newsList, pageable, countQuery::fetchOne);
     }
 
-    private List<News> getNewsByPageable(
-            Pageable pageable, BooleanExpression predicate, NewsSort newsSort) {
-        if (newsSort == NewsSort.POPULAR) {
-            return queryFactory
-                    .selectFrom(news)
-                    .where(predicate)
-                    .orderBy(
-                            news.views.desc(), // 조회수 내림차순
-                            news.createdDate.desc() // 생성일 내림차순
-                            )
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize())
-                    .fetch();
-        } else {
-            return queryFactory
-                    .selectFrom(news)
-                    .where(predicate)
-                    .orderBy(news.createdDate.desc()) // 생성일 내림차순
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize())
-                    .fetch();
-        }
+    private List<News> getNewsWithScrapByPageable(
+            Pageable pageable, BooleanExpression predicate, NewsSort newsSort, long userId) {
+
+        // 동적으로 정렬 조건 설정
+        var orderBy =
+                (newsSort == NewsSort.POPULAR)
+                        ? new com.querydsl.core.types.OrderSpecifier[] {
+                            news.views.desc(), news.createdDate.desc()
+                        }
+                        : new com.querydsl.core.types.OrderSpecifier[] {news.createdDate.desc()};
+
+        List<Tuple> results =
+                queryFactory
+                        .select(news, newsScrap.id)
+                        .from(news)
+                        .leftJoin(newsScrap)
+                        .on(news.id.eq(newsScrap.news.id).and(newsScrap.user.id.eq(userId)))
+                        .where(predicate)
+                        .orderBy(orderBy)
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch();
+
+        return results.stream()
+                .map(
+                        tuple -> {
+                            News news = tuple.get(QNews.news);
+                            Long scrapId = tuple.get(newsScrap.id);
+                            news.setIsScrapped(scrapId != null);
+                            return news;
+                        })
+                .toList();
     }
 }

--- a/src/main/java/com/ripple/BE/news/service/NewsService.java
+++ b/src/main/java/com/ripple/BE/news/service/NewsService.java
@@ -18,6 +18,7 @@ import com.ripple.BE.user.service.UserService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -39,6 +40,10 @@ public class NewsService {
 
     private static final int PAGE_SIZE = 10;
 
+    @Cacheable(
+            value = "newsList",
+            key =
+                    "#page + (#sort != null ? #sort.toString() : '') + (#category != null ? #category.toString() : '')")
     @Transactional(readOnly = true)
     public NewsListDTO getNewsList(final int page, final NewsSort sort, final NewsCategory category) {
 

--- a/src/main/java/com/ripple/BE/news/service/NewsService.java
+++ b/src/main/java/com/ripple/BE/news/service/NewsService.java
@@ -45,15 +45,16 @@ public class NewsService {
             key =
                     "#page + (#sort != null ? #sort.toString() : '') + (#category != null ? #category.toString() : '')")
     @Transactional(readOnly = true)
-    public NewsListDTO getNewsList(final int page, final NewsSort sort, final NewsCategory category) {
+    public NewsListDTO getNewsList(
+            final int page, final NewsSort sort, final NewsCategory category, final long userId) {
 
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
 
         // 게시글 조회 (타입에 따른 필터링)
         Page<News> newsPage =
                 category == null
-                        ? newsRepository.findAll(pageable, sort) // 일반 게시글 조회
-                        : newsRepository.findByCategory(category, sort, pageable); // 특정 타입 게시글 조회
+                        ? newsRepository.findAll(pageable, sort, userId) // 일반 게시글 조회
+                        : newsRepository.findByCategory(category, sort, pageable, userId); // 특정 타입 게시글 조회
 
         return NewsListDTO.toNewsListDTO(newsPage);
     }

--- a/src/main/java/com/ripple/BE/post/controller/PostController.java
+++ b/src/main/java/com/ripple/BE/post/controller/PostController.java
@@ -83,11 +83,12 @@ public class PostController {
     @Operation(summary = "게시글 목록 조회", description = "게시글 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<Object>> getPosts(
+            final @AuthenticationPrincipal CustomUserDetails currentUser,
             final @RequestParam(required = false, defaultValue = "0") @PositiveOrZero int page,
             final @RequestParam(required = false, defaultValue = "RECENT") PostSort sort,
             final @RequestParam(required = false) PostType type) {
 
-        PostListDTO postListDTO = postService.getPosts(page, sort, type);
+        PostListDTO postListDTO = postService.getPosts(page, sort, type, currentUser.getId());
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.from(PostListResponse.toPostListResponse(postListDTO)));

--- a/src/main/java/com/ripple/BE/post/controller/ToktokController.java
+++ b/src/main/java/com/ripple/BE/post/controller/ToktokController.java
@@ -8,12 +8,14 @@ import com.ripple.BE.post.dto.response.ToktokPreviewListResponse;
 import com.ripple.BE.post.dto.response.ToktokPreviewResponse;
 import com.ripple.BE.post.dto.response.ToktokResponse;
 import com.ripple.BE.post.service.ToktokService;
+import com.ripple.BE.user.domain.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,9 +42,10 @@ public class ToktokController {
     @Operation(summary = "경제 톡톡 목록 조회", description = "경제 톡톡 목록을 조회합니다.")
     @GetMapping("/toktok")
     public ResponseEntity<ApiResponse<Object>> getToktoks(
+            final @AuthenticationPrincipal CustomUserDetails currentUser,
             final @RequestParam(required = false, defaultValue = "0") @PositiveOrZero int page,
             final @RequestParam(required = false, defaultValue = "RECENT") PostSort sort) {
-        PostListDTO postListDTO = toktokService.getToktoks(page, sort);
+        PostListDTO postListDTO = toktokService.getToktoks(page, sort, currentUser.getId());
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.from(ToktokPreviewListResponse.toToktokPreviewListResponse(postListDTO)));

--- a/src/main/java/com/ripple/BE/post/domain/Post.java
+++ b/src/main/java/com/ripple/BE/post/domain/Post.java
@@ -17,6 +17,7 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -70,6 +71,8 @@ public class Post extends BaseEntity {
     @Setter
     @Column(name = "used_date")
     private LocalDate usedDate; // 사용 날짜
+
+    @Setter @Transient private Boolean isScrapped;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> commentList = new ArrayList<>(); // 댓글 목록

--- a/src/main/java/com/ripple/BE/post/dto/CommentDTO.java
+++ b/src/main/java/com/ripple/BE/post/dto/CommentDTO.java
@@ -1,5 +1,9 @@
 package com.ripple.BE.post.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.ripple.BE.post.domain.Comment;
 import com.ripple.BE.user.dto.CommunityUserDTO;
 import java.time.LocalDateTime;
@@ -13,8 +17,12 @@ public record CommentDTO(
         boolean isDeleted,
         long replyCount,
         List<CommentDTO> children,
-        LocalDateTime createdDate,
-        LocalDateTime modifiedDate) {
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+                @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+                LocalDateTime createdDate,
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+                @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+                LocalDateTime modifiedDate) {
 
     public static CommentDTO toCommentDTO(Comment comment) {
         return new CommentDTO(

--- a/src/main/java/com/ripple/BE/post/dto/PostDTO.java
+++ b/src/main/java/com/ripple/BE/post/dto/PostDTO.java
@@ -1,5 +1,11 @@
 package com.ripple.BE.post.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.ripple.BE.image.dto.ImageListDTO;
 import com.ripple.BE.post.domain.Post;
 import com.ripple.BE.post.domain.type.PostType;
@@ -19,9 +25,15 @@ public record PostDTO(
         Long commentCount,
         Long scrapCount,
         ImageListDTO imageList,
-        LocalDateTime createdDate,
-        LocalDateTime modifiedDate,
-        LocalDate usedDate,
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+                @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+                LocalDateTime createdDate,
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+                @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+                LocalDateTime modifiedDate,
+        @JsonSerialize(using = LocalDateSerializer.class)
+                @JsonDeserialize(using = LocalDateDeserializer.class)
+                LocalDate usedDate,
         CommentListDTO commentListDTO) {
 
     public static PostDTO toPostDTO(final Post post) {

--- a/src/main/java/com/ripple/BE/post/dto/PostDTO.java
+++ b/src/main/java/com/ripple/BE/post/dto/PostDTO.java
@@ -25,6 +25,7 @@ public record PostDTO(
         Long commentCount,
         Long scrapCount,
         ImageListDTO imageList,
+        Boolean isScraped,
         @JsonSerialize(using = LocalDateTimeSerializer.class)
                 @JsonDeserialize(using = LocalDateTimeDeserializer.class)
                 LocalDateTime createdDate,
@@ -47,10 +48,11 @@ public record PostDTO(
                 post.getCommentCount(),
                 post.getScrapCount(),
                 ImageListDTO.toImageListDTO(post.getImageList()),
+                post.getIsScrapped(),
                 post.getCreatedDate(),
                 post.getModifiedDate(),
                 post.getUsedDate(),
-                CommentListDTO.toCommentListDTO(post.getCommentList()));
+                null);
     }
 
     public static PostDTO toPostDTO(final Post post, final CommentListDTO commentListDTO) {
@@ -64,6 +66,7 @@ public record PostDTO(
                 post.getCommentCount(),
                 post.getScrapCount(),
                 ImageListDTO.toImageListDTO(post.getImageList()),
+                post.getIsScrapped(),
                 post.getCreatedDate(),
                 post.getModifiedDate(),
                 post.getUsedDate(),
@@ -84,6 +87,7 @@ public record PostDTO(
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 
@@ -94,6 +98,7 @@ public record PostDTO(
                 null,
                 request.content(),
                 request.type(),
+                null,
                 null,
                 null,
                 null,

--- a/src/main/java/com/ripple/BE/post/dto/response/PostPreviewResponse.java
+++ b/src/main/java/com/ripple/BE/post/dto/response/PostPreviewResponse.java
@@ -12,6 +12,7 @@ public record PostPreviewResponse(
         long likeCount,
         long commentCount,
         String imageUrl,
+        Boolean isScraped,
         String createdDate) {
 
     public static PostPreviewResponse toPostPreviewResponse(PostDTO postDTO) {
@@ -25,6 +26,7 @@ public record PostPreviewResponse(
                 postDTO.imageList().imageDTOList().isEmpty()
                         ? null
                         : postDTO.imageList().imageDTOList().get(0).url(),
+                postDTO.isScraped(),
                 RelativeTimeFormatter.formatRelativeTime(postDTO.createdDate()));
     }
 }

--- a/src/main/java/com/ripple/BE/post/dto/response/ToktokPreviewResponse.java
+++ b/src/main/java/com/ripple/BE/post/dto/response/ToktokPreviewResponse.java
@@ -9,6 +9,7 @@ public record ToktokPreviewResponse(
         long participantCount,
         long likeCount,
         String imageUrl,
+        Boolean isScraped,
         String createdDate) {
 
     public static ToktokPreviewResponse toToktokPreviewResponse(PostDTO postDTO) {
@@ -21,6 +22,7 @@ public record ToktokPreviewResponse(
                 postDTO.imageList().imageDTOList().isEmpty()
                         ? null
                         : postDTO.imageList().imageDTOList().get(0).url(),
+                postDTO.isScraped(),
                 RelativeTimeFormatter.formatRelativeTime(postDTO.usedDate().atStartOfDay()));
     }
 }

--- a/src/main/java/com/ripple/BE/post/dto/response/ToktokPreviewResponse.java
+++ b/src/main/java/com/ripple/BE/post/dto/response/ToktokPreviewResponse.java
@@ -4,7 +4,12 @@ import com.ripple.BE.global.utils.RelativeTimeFormatter;
 import com.ripple.BE.post.dto.PostDTO;
 
 public record ToktokPreviewResponse(
-        Long id, String title, long participantCount, String imageUrl, String createdDate) {
+        Long id,
+        String title,
+        long participantCount,
+        long likeCount,
+        String imageUrl,
+        String createdDate) {
 
     public static ToktokPreviewResponse toToktokPreviewResponse(PostDTO postDTO) {
 
@@ -12,6 +17,7 @@ public record ToktokPreviewResponse(
                 postDTO.id(),
                 postDTO.title(),
                 postDTO.commentCount(),
+                postDTO.likeCount(),
                 postDTO.imageList().imageDTOList().isEmpty()
                         ? null
                         : postDTO.imageList().imageDTOList().get(0).url(),

--- a/src/main/java/com/ripple/BE/post/repository/post/PostRepositoryCustom.java
+++ b/src/main/java/com/ripple/BE/post/repository/post/PostRepositoryCustom.java
@@ -11,19 +11,19 @@ import org.springframework.data.domain.Pageable;
 
 public interface PostRepositoryCustom {
 
-    Page<Post> findByType(PostType type, PostSort postSort, Pageable pageable);
+    Page<Post> findByType(PostType type, PostSort postSort, Pageable pageable, long userId);
 
-    Page<Post> findNormalPosts(Pageable pageable, PostSort postSort);
+    Page<Post> findNormalPosts(Pageable pageable, PostSort postSort, long userId);
 
     List<Post> findUserNormalPosts(Long userId);
 
     List<Post> findNewToktokPosts();
 
-    Page<Post> findUsedToktokPosts(Pageable pageable, PostSort postSort);
+    Page<Post> findUsedToktokPosts(Pageable pageable, PostSort postSort, long userId);
 
     Optional<Post> findTodayToktokPost(LocalDate today);
 
-    Page<Post> searchNormalPosts(String keyword, Pageable pageable);
+    Page<Post> searchNormalPosts(String keyword, Pageable pageable, long userId);
 
-    Page<Post> searchUsedToktokPosts(String keyword, Pageable pageable);
+    Page<Post> searchUsedToktokPosts(String keyword, Pageable pageable, long userId);
 }

--- a/src/main/java/com/ripple/BE/post/repository/post/PostRepositoryCustom.java
+++ b/src/main/java/com/ripple/BE/post/repository/post/PostRepositoryCustom.java
@@ -22,4 +22,8 @@ public interface PostRepositoryCustom {
     Page<Post> findUsedToktokPosts(Pageable pageable, PostSort postSort);
 
     Optional<Post> findTodayToktokPost(LocalDate today);
+
+    Page<Post> searchNormalPosts(String keyword, Pageable pageable);
+
+    Page<Post> searchUsedToktokPosts(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/ripple/BE/post/repository/post/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/ripple/BE/post/repository/post/PostRepositoryCustomImpl.java
@@ -1,11 +1,16 @@
 package com.ripple.BE.post.repository.post;
 
+import static com.ripple.BE.news.domain.QNews.*;
+import static com.ripple.BE.news.domain.QNewsScrap.*;
 import static com.ripple.BE.post.domain.QPost.post;
+import static com.ripple.BE.post.domain.QPostScrap.*;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ripple.BE.post.domain.Post;
+import com.ripple.BE.post.domain.QPost;
 import com.ripple.BE.post.domain.type.PostSort;
 import com.ripple.BE.post.domain.type.PostType;
 import java.time.LocalDate;
@@ -22,10 +27,10 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Post> findByType(PostType type, PostSort postSort, Pageable pageable) {
+    public Page<Post> findByType(PostType type, PostSort postSort, Pageable pageable, long userId) {
         BooleanExpression predicate = post.type.eq(type);
 
-        List<Post> posts = getPostsByPageable(pageable, predicate, postSort);
+        List<Post> posts = getPostsWithScrapByPageable(pageable, predicate, postSort, userId);
 
         JPAQuery<Long> countQuery = queryFactory.select(post.count()).from(post).where(predicate);
 
@@ -33,11 +38,11 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public Page<Post> findNormalPosts(Pageable pageable, PostSort postSort) {
+    public Page<Post> findNormalPosts(Pageable pageable, PostSort postSort, long userId) {
 
         BooleanExpression predicate = post.type.ne(PostType.ECONOMY_TALK);
 
-        List<Post> posts = getPostsByPageable(pageable, predicate, postSort);
+        List<Post> posts = getPostsWithScrapByPageable(pageable, predicate, postSort, userId);
 
         JPAQuery<Long> countQuery = queryFactory.select(post.count()).from(post).where(predicate);
 
@@ -45,7 +50,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public Page<Post> searchNormalPosts(String keyword, Pageable pageable) {
+    public Page<Post> searchNormalPosts(String keyword, Pageable pageable, long userId) {
         BooleanExpression predicate = null;
 
         if (keyword != null && !keyword.trim().isEmpty()) {
@@ -55,7 +60,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                             .and(post.title.contains(keyword).or(post.content.contains(keyword)));
         }
 
-        List<Post> posts = getPostsByPageable(pageable, predicate, PostSort.RECENT);
+        List<Post> posts = getPostsWithScrapByPageable(pageable, predicate, PostSort.RECENT, userId);
 
         JPAQuery<Long> countQuery = queryFactory.select(post.count()).from(post).where(predicate);
 
@@ -63,7 +68,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public Page<Post> searchUsedToktokPosts(String keyword, Pageable pageable) {
+    public Page<Post> searchUsedToktokPosts(String keyword, Pageable pageable, long userId) {
         BooleanExpression predicate = null;
 
         if (keyword != null && !keyword.trim().isEmpty()) {
@@ -74,7 +79,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                             .and(post.title.contains(keyword).or(post.content.contains(keyword)));
         }
 
-        List<Post> posts = getPostsByPageableWithToktok(pageable, predicate, PostSort.RECENT);
+        List<Post> posts = getToktoksWithScrapByPageable(pageable, predicate, PostSort.RECENT, userId);
 
         JPAQuery<Long> countQuery = queryFactory.select(post.count()).from(post).where(predicate);
 
@@ -97,11 +102,11 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public Page<Post> findUsedToktokPosts(Pageable pageable, PostSort postSort) {
+    public Page<Post> findUsedToktokPosts(Pageable pageable, PostSort postSort, long userId) {
         BooleanExpression predicate =
                 post.type.eq(PostType.ECONOMY_TALK).and(post.usedDate.isNotNull());
 
-        List<Post> posts = getPostsByPageableWithToktok(pageable, predicate, postSort);
+        List<Post> posts = getToktoksWithScrapByPageable(pageable, predicate, postSort, userId);
 
         JPAQuery<Long> countQuery = queryFactory.select(post.count()).from(post).where(predicate);
 
@@ -115,51 +120,55 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
         return Optional.ofNullable(result);
     }
 
-    private List<Post> getPostsByPageable(
-            Pageable pageable, BooleanExpression predicate, PostSort postSort) {
-        if (postSort == PostSort.POPULAR) {
-            return queryFactory
-                    .selectFrom(post)
-                    .where(predicate)
-                    .orderBy(
-                            post.likeCount.desc(), // 좋아요 수 내림차순
-                            post.createdDate.desc() // 생성일 내림차순
-                            )
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize())
-                    .fetch();
-        } else {
-            return queryFactory
-                    .selectFrom(post)
-                    .where(predicate)
-                    .orderBy(post.createdDate.desc()) // 생성일 내림차순
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize())
-                    .fetch();
-        }
+    private List<Post> getPostsWithScrapByPageable(
+            Pageable pageable, BooleanExpression predicate, PostSort postSort, long userId) {
+
+        return getPostsOrToktoksWithScrapByPageable(pageable, predicate, postSort, userId, false);
     }
 
-    private List<Post> getPostsByPageableWithToktok(
-            Pageable pageable, BooleanExpression predicate, PostSort postSort) {
-        if (postSort == PostSort.POPULAR) {
-            return queryFactory
-                    .selectFrom(post)
-                    .where(predicate)
-                    .orderBy(
-                            post.likeCount.desc(), // 좋아요 수 내림차순
-                            post.createdDate.desc() // 생성일 내림차순
-                            )
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize())
-                    .fetch();
-        } else {
-            return queryFactory
-                    .selectFrom(post)
-                    .where(predicate)
-                    .orderBy(post.usedDate.desc()) // 사용일 내림차순
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize())
-                    .fetch();
-        }
+    private List<Post> getToktoksWithScrapByPageable(
+            Pageable pageable, BooleanExpression predicate, PostSort postSort, long userId) {
+
+        return getPostsOrToktoksWithScrapByPageable(pageable, predicate, postSort, userId, true);
+    }
+
+    private List<Post> getPostsOrToktoksWithScrapByPageable(
+            Pageable pageable,
+            BooleanExpression predicate,
+            PostSort postSort,
+            long userId,
+            boolean isToktok) {
+
+        // 동적으로 정렬 조건 설정
+        var orderBy =
+                (postSort == PostSort.POPULAR)
+                        ? new com.querydsl.core.types.OrderSpecifier[] {
+                            post.likeCount.desc(), post.createdDate.desc()
+                        }
+                        : new com.querydsl.core.types.OrderSpecifier[] {
+                            isToktok ? post.usedDate.desc() : post.createdDate.desc()
+                        };
+
+        List<Tuple> results =
+                queryFactory
+                        .select(post, postScrap.id) // post와 postScrap.id를 함께 조회
+                        .from(post)
+                        .leftJoin(postScrap)
+                        .on(post.id.eq(postScrap.post.id).and(postScrap.user.id.eq(userId)))
+                        .where(predicate)
+                        .orderBy(orderBy)
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch();
+
+        return results.stream()
+                .map(
+                        tuple -> {
+                            Post post = tuple.get(QPost.post);
+                            Long scrapId = tuple.get(postScrap.id);
+                            post.setIsScrapped(scrapId != null);
+                            return post;
+                        })
+                .toList();
     }
 }

--- a/src/main/java/com/ripple/BE/post/repository/post/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/ripple/BE/post/repository/post/PostRepositoryCustomImpl.java
@@ -45,6 +45,43 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
     }
 
     @Override
+    public Page<Post> searchNormalPosts(String keyword, Pageable pageable) {
+        BooleanExpression predicate = null;
+
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            predicate =
+                    post.type
+                            .ne(PostType.ECONOMY_TALK)
+                            .and(post.title.contains(keyword).or(post.content.contains(keyword)));
+        }
+
+        List<Post> posts = getPostsByPageable(pageable, predicate, PostSort.RECENT);
+
+        JPAQuery<Long> countQuery = queryFactory.select(post.count()).from(post).where(predicate);
+
+        return PageableExecutionUtils.getPage(posts, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Page<Post> searchUsedToktokPosts(String keyword, Pageable pageable) {
+        BooleanExpression predicate = null;
+
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            predicate =
+                    post.type
+                            .eq(PostType.ECONOMY_TALK)
+                            .and(post.usedDate.isNotNull())
+                            .and(post.title.contains(keyword).or(post.content.contains(keyword)));
+        }
+
+        List<Post> posts = getPostsByPageableWithToktok(pageable, predicate, PostSort.RECENT);
+
+        JPAQuery<Long> countQuery = queryFactory.select(post.count()).from(post).where(predicate);
+
+        return PageableExecutionUtils.getPage(posts, pageable, countQuery::fetchOne);
+    }
+
+    @Override
     public List<Post> findUserNormalPosts(Long userId) {
 
         BooleanExpression predicate =

--- a/src/main/java/com/ripple/BE/post/service/PostService.java
+++ b/src/main/java/com/ripple/BE/post/service/PostService.java
@@ -28,6 +28,7 @@ import com.ripple.BE.user.service.UserService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -117,6 +118,10 @@ public class PostService {
         postRepository.delete(post);
     }
 
+    @Cacheable(
+            value = "posts",
+            key =
+                    "#page + (#sort != null ? #sort.toString() : '') + (#type != null ? #type.toString() : '')")
     @Transactional(readOnly = true)
     public PostListDTO getPosts(final int page, final PostSort sort, final PostType type) {
 

--- a/src/main/java/com/ripple/BE/post/service/PostService.java
+++ b/src/main/java/com/ripple/BE/post/service/PostService.java
@@ -123,15 +123,16 @@ public class PostService {
             key =
                     "#page + (#sort != null ? #sort.toString() : '') + (#type != null ? #type.toString() : '')")
     @Transactional(readOnly = true)
-    public PostListDTO getPosts(final int page, final PostSort sort, final PostType type) {
+    public PostListDTO getPosts(
+            final int page, final PostSort sort, final PostType type, final long userId) {
 
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
 
         // 게시글 조회 (타입에 따른 필터링)
         Page<Post> postPage =
                 type == null
-                        ? postRepository.findNormalPosts(pageable, sort) // 일반 게시글 조회
-                        : postRepository.findByType(type, sort, pageable); // 특정 타입 게시글 조회
+                        ? postRepository.findNormalPosts(pageable, sort, userId) // 일반 게시글 조회
+                        : postRepository.findByType(type, sort, pageable, userId); // 특정 타입 게시글 조회
 
         return PostListDTO.toPostListDTO(postPage);
     }

--- a/src/main/java/com/ripple/BE/post/service/ToktokService.java
+++ b/src/main/java/com/ripple/BE/post/service/ToktokService.java
@@ -58,12 +58,12 @@ public class ToktokService {
     }
 
     @Transactional(readOnly = true)
-    public PostListDTO getToktoks(final int page, final PostSort sort) {
+    public PostListDTO getToktoks(final int page, final PostSort sort, final long userId) {
 
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
 
         // 게시글 조회 (타입에 따른 필터링)
-        Page<Post> postPage = postRepository.findUsedToktokPosts(pageable, sort);
+        Page<Post> postPage = postRepository.findUsedToktokPosts(pageable, sort, userId);
 
         return PostListDTO.toPostListDTO(postPage);
     }

--- a/src/main/java/com/ripple/BE/search/controller/SearchController.java
+++ b/src/main/java/com/ripple/BE/search/controller/SearchController.java
@@ -1,0 +1,118 @@
+package com.ripple.BE.search.controller;
+
+import com.ripple.BE.global.dto.response.ApiResponse;
+import com.ripple.BE.news.dto.NewsListDTO;
+import com.ripple.BE.news.dto.response.NewsListResponse;
+import com.ripple.BE.post.dto.PostListDTO;
+import com.ripple.BE.post.dto.response.PostListResponse;
+import com.ripple.BE.post.dto.response.ToktokPreviewListResponse;
+import com.ripple.BE.search.dto.SearchKeywordListDTO;
+import com.ripple.BE.search.dto.response.SearchKeywordListResponse;
+import com.ripple.BE.search.service.SearchService;
+import com.ripple.BE.term.dto.TermListDTO;
+import com.ripple.BE.term.dto.response.TermListResponse;
+import com.ripple.BE.user.domain.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/search")
+@Tag(name = "Search", description = "검색 API")
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @Operation(summary = "일반 게시글 검색", description = "일반 게시글을 검색합니다.")
+    @GetMapping("/posts")
+    public ResponseEntity<ApiResponse<Object>> searchPosts(
+            final @AuthenticationPrincipal CustomUserDetails currentUser,
+            final @RequestParam(value = "keyword", required = false) String keyword,
+            final @RequestParam(value = "page", defaultValue = "0") @PositiveOrZero int page) {
+
+        PostListDTO postListDTO = searchService.searchPosts(keyword, page, currentUser.getId());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.from(PostListResponse.toPostListResponse(postListDTO)));
+    }
+
+    @Operation(summary = "톡톡 게시글 검색", description = "톡톡 게시글을 검색합니다.")
+    @GetMapping("/toktoks")
+    public ResponseEntity<ApiResponse<Object>> searchToktoks(
+            final @AuthenticationPrincipal CustomUserDetails currentUser,
+            final @RequestParam(value = "keyword", required = false) String keyword,
+            final @RequestParam(value = "page", defaultValue = "0") @PositiveOrZero int page) {
+
+        PostListDTO postListDTO = searchService.searchToktoks(keyword, page, currentUser.getId());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.from(ToktokPreviewListResponse.toToktokPreviewListResponse(postListDTO)));
+    }
+
+    @Operation(summary = "뉴스 검색", description = "뉴스를 검색합니다.")
+    @GetMapping("/news")
+    public ResponseEntity<ApiResponse<Object>> searchNews(
+            final @AuthenticationPrincipal CustomUserDetails currentUser,
+            final @RequestParam(value = "keyword", required = false) String keyword,
+            final @RequestParam(value = "page", defaultValue = "0") @PositiveOrZero int page) {
+
+        NewsListDTO newsListDTO = searchService.searchNews(keyword, page, currentUser.getId());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.from(NewsListResponse.toNewsListResponse(newsListDTO)));
+    }
+
+    @Operation(summary = "용어 검색", description = "용어를 검색합니다.")
+    @GetMapping("/terms")
+    public ResponseEntity<ApiResponse<Object>> searchTerms(
+            final @AuthenticationPrincipal CustomUserDetails currentUser,
+            final @RequestParam(value = "keyword", required = false) String keyword,
+            final @RequestParam(value = "page", defaultValue = "0") @PositiveOrZero int page) {
+
+        TermListDTO termListDTO = searchService.searchTerms(keyword, page, currentUser.getId());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.from(TermListResponse.toTermListResponse(termListDTO)));
+    }
+
+    @Operation(summary = "최근 검색어 조회", description = "사용자의 최근 검색어를 조회합니다.")
+    @GetMapping("/recent")
+    public ResponseEntity<ApiResponse<Object>> getRecentSearches(
+            final @AuthenticationPrincipal CustomUserDetails currentUser) {
+
+        SearchKeywordListDTO searchKeywordListDTO =
+                searchService.getRecentSearches(currentUser.getId());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(
+                        ApiResponse.from(
+                                SearchKeywordListResponse.toSearchKeywordListResponse(searchKeywordListDTO)));
+    }
+
+    @Operation(summary = "검색어 삭제", description = "사용자의 최근 검색어를 삭제합니다.")
+    @DeleteMapping("/recent")
+    public ResponseEntity<ApiResponse<Object>> deleteRecentSearch(
+            final @AuthenticationPrincipal CustomUserDetails currentUser,
+            final @RequestParam(value = "keyword") String keyword) {
+
+        searchService.removeSearchKeyword(currentUser.getId(), keyword);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(ApiResponse.EMPTY_RESPONSE));
+    }
+
+    @Operation(summary = "검색어 전체 삭제", description = "사용자의 최근 검색어를 전체 삭제합니다.")
+    @DeleteMapping("/recent/all")
+    public ResponseEntity<ApiResponse<Object>> deleteAllRecentSearch(
+            final @AuthenticationPrincipal CustomUserDetails currentUser) {
+
+        searchService.clearRecentSearches(currentUser.getId());
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(ApiResponse.EMPTY_RESPONSE));
+    }
+}

--- a/src/main/java/com/ripple/BE/search/dto/SearchKeywordDTO.java
+++ b/src/main/java/com/ripple/BE/search/dto/SearchKeywordDTO.java
@@ -1,0 +1,8 @@
+package com.ripple.BE.search.dto;
+
+public record SearchKeywordDTO(String keyword) {
+
+    public static SearchKeywordDTO toSearchKeywordDTO(final String keyword) {
+        return new SearchKeywordDTO(keyword);
+    }
+}

--- a/src/main/java/com/ripple/BE/search/dto/SearchKeywordListDTO.java
+++ b/src/main/java/com/ripple/BE/search/dto/SearchKeywordListDTO.java
@@ -1,0 +1,11 @@
+package com.ripple.BE.search.dto;
+
+import java.util.List;
+
+public record SearchKeywordListDTO(List<SearchKeywordDTO> searchKeywordDTOList) {
+
+    public static SearchKeywordListDTO toSearchKeywordListDTO(List<String> searchKeywordList) {
+        return new SearchKeywordListDTO(
+                searchKeywordList.stream().map(SearchKeywordDTO::toSearchKeywordDTO).toList());
+    }
+}

--- a/src/main/java/com/ripple/BE/search/dto/response/SearchKeywordListResponse.java
+++ b/src/main/java/com/ripple/BE/search/dto/response/SearchKeywordListResponse.java
@@ -1,0 +1,15 @@
+package com.ripple.BE.search.dto.response;
+
+import com.ripple.BE.search.dto.SearchKeywordListDTO;
+import java.util.List;
+
+public record SearchKeywordListResponse(List<SearchKeywordResponse> searchKeywords) {
+
+    public static SearchKeywordListResponse toSearchKeywordListResponse(
+            SearchKeywordListDTO searchKeywordListDTO) {
+        return new SearchKeywordListResponse(
+                searchKeywordListDTO.searchKeywordDTOList().stream()
+                        .map(SearchKeywordResponse::toSearchKeywordResponse)
+                        .toList());
+    }
+}

--- a/src/main/java/com/ripple/BE/search/dto/response/SearchKeywordResponse.java
+++ b/src/main/java/com/ripple/BE/search/dto/response/SearchKeywordResponse.java
@@ -1,0 +1,10 @@
+package com.ripple.BE.search.dto.response;
+
+import com.ripple.BE.search.dto.SearchKeywordDTO;
+
+public record SearchKeywordResponse(String keyword) {
+    public static SearchKeywordResponse toSearchKeywordResponse(
+            final SearchKeywordDTO searchKeywordDTO) {
+        return new SearchKeywordResponse(searchKeywordDTO.keyword());
+    }
+}

--- a/src/main/java/com/ripple/BE/search/service/SearchService.java
+++ b/src/main/java/com/ripple/BE/search/service/SearchService.java
@@ -44,7 +44,7 @@ public class SearchService {
     public PostListDTO searchPosts(final String keyword, final int page, final long userId) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
 
-        Page<Post> postPage = postRepository.searchNormalPosts(keyword, pageable);
+        Page<Post> postPage = postRepository.searchNormalPosts(keyword, pageable, userId);
         addRecentSearch(userId, keyword);
 
         return PostListDTO.toPostListDTO(postPage);
@@ -55,7 +55,7 @@ public class SearchService {
     public PostListDTO searchToktoks(final String keyword, final int page, final long userId) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
 
-        Page<Post> postPage = postRepository.searchUsedToktokPosts(keyword, pageable);
+        Page<Post> postPage = postRepository.searchUsedToktokPosts(keyword, pageable, userId);
         addRecentSearch(userId, keyword);
 
         return PostListDTO.toPostListDTO(postPage);
@@ -66,7 +66,7 @@ public class SearchService {
     public NewsListDTO searchNews(final String keyword, final int page, final long userId) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
 
-        Page<News> newsPage = newsRepository.searchNews(keyword, pageable);
+        Page<News> newsPage = newsRepository.searchNews(keyword, pageable, userId);
         addRecentSearch(userId, keyword);
 
         return NewsListDTO.toNewsListDTO(newsPage);
@@ -77,7 +77,7 @@ public class SearchService {
     public TermListDTO searchTerms(final String keyword, final int page, final long userId) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
 
-        Page<Term> termPage = termRepository.searchTerms(keyword, pageable);
+        Page<Term> termPage = termRepository.searchTerms(keyword, pageable, userId);
         addRecentSearch(userId, keyword);
 
         return TermListDTO.toTermListDTO(termPage);

--- a/src/main/java/com/ripple/BE/search/service/SearchService.java
+++ b/src/main/java/com/ripple/BE/search/service/SearchService.java
@@ -1,0 +1,125 @@
+package com.ripple.BE.search.service;
+
+import com.ripple.BE.news.domain.News;
+import com.ripple.BE.news.dto.NewsListDTO;
+import com.ripple.BE.news.repository.news.NewsRepository;
+import com.ripple.BE.post.domain.Post;
+import com.ripple.BE.post.dto.PostListDTO;
+import com.ripple.BE.post.repository.post.PostRepository;
+import com.ripple.BE.search.dto.SearchKeywordListDTO;
+import com.ripple.BE.term.domain.Term;
+import com.ripple.BE.term.dto.TermListDTO;
+import com.ripple.BE.term.repository.TermRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class SearchService {
+
+    private final int PAGE_SIZE = 10;
+    private static final int MAX_RECENT_SEARCHES = 20; // 최대 최근 검색어 개수
+    private static final long EXPIRATION_TIME = 7; // 데이터 만료 기간 (7일)
+    private static final String SEARCH_KEYWORD_KEY = "search:keyword:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private final PostRepository postRepository;
+    private final NewsRepository newsRepository;
+    private final TermRepository termRepository;
+
+    @Cacheable(value = "postSearch", key = "#keyword != null ? #keyword + #page : #page")
+    @Transactional(readOnly = true)
+    public PostListDTO searchPosts(final String keyword, final int page, final long userId) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+
+        Page<Post> postPage = postRepository.searchNormalPosts(keyword, pageable);
+        addRecentSearch(userId, keyword);
+
+        return PostListDTO.toPostListDTO(postPage);
+    }
+
+    @Cacheable(value = "toktokSearch", key = "#keyword != null ? #keyword + #page : #page")
+    @Transactional(readOnly = true)
+    public PostListDTO searchToktoks(final String keyword, final int page, final long userId) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+
+        Page<Post> postPage = postRepository.searchUsedToktokPosts(keyword, pageable);
+        addRecentSearch(userId, keyword);
+
+        return PostListDTO.toPostListDTO(postPage);
+    }
+
+    @Cacheable(value = "newsSearch", key = "#keyword != null ? #keyword + #page : #page")
+    @Transactional(readOnly = true)
+    public NewsListDTO searchNews(final String keyword, final int page, final long userId) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+
+        Page<News> newsPage = newsRepository.searchNews(keyword, pageable);
+        addRecentSearch(userId, keyword);
+
+        return NewsListDTO.toNewsListDTO(newsPage);
+    }
+
+    @Cacheable(value = "termSearch", key = "#keyword != null ? #keyword + #page : #page")
+    @Transactional(readOnly = true)
+    public TermListDTO searchTerms(final String keyword, final int page, final long userId) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+
+        Page<Term> termPage = termRepository.searchTerms(keyword, pageable);
+        addRecentSearch(userId, keyword);
+
+        return TermListDTO.toTermListDTO(termPage);
+    }
+
+    public SearchKeywordListDTO getRecentSearches(final long userId) {
+        String key = getKey(userId);
+        List<String> searchKeywords =
+                Optional.ofNullable(redisTemplate.opsForList().range(key, 0, -1)).orElse(List.of());
+
+        return SearchKeywordListDTO.toSearchKeywordListDTO(searchKeywords);
+    }
+
+    private void addRecentSearch(final long userId, final String keyword) {
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return;
+        }
+
+        String key = getKey(userId);
+
+        redisTemplate.opsForList().remove(key, 0, keyword); // 중복 검색어 제거
+
+        redisTemplate.opsForList().leftPush(key, keyword); // 최근 검색어 추가
+
+        redisTemplate.opsForList().trim(key, 0, MAX_RECENT_SEARCHES - 1); // 최근 검색어 개수 제한
+
+        redisTemplate.expire(key, EXPIRATION_TIME, TimeUnit.DAYS); // 만료 시간 설정
+    }
+
+    public void clearRecentSearches(final long userId) {
+        String key = getKey(userId);
+        redisTemplate.delete(key);
+    }
+
+    public void removeSearchKeyword(final long userId, String keyword) {
+        String key = getKey(userId);
+
+        redisTemplate.opsForList().remove(key, 0, keyword);
+    }
+
+    // Redis 키 생성
+    private String getKey(final long userId) {
+        return SEARCH_KEYWORD_KEY + userId;
+    }
+}

--- a/src/main/java/com/ripple/BE/term/controller/TermController.java
+++ b/src/main/java/com/ripple/BE/term/controller/TermController.java
@@ -38,6 +38,7 @@ public class TermController {
     @Operation(summary = "자음 별 용어 조회", description = "자음 별 용어를 조회합니다.")
     @GetMapping("/search/consonant")
     public ResponseEntity<ApiResponse<Object>> getTermsByInitial(
+            final @AuthenticationPrincipal CustomUserDetails currentUser,
             final @RequestParam(required = false, defaultValue = "0") @PositiveOrZero int page,
             @RequestParam(value = "consonant", required = false, defaultValue = "ㄱ")
                     final String consonant) {
@@ -46,7 +47,7 @@ public class TermController {
             throw new TermException(INVALID_PARAMETER);
         }
 
-        TermListDTO termListDTO = termService.getTermsByInitial(page, consonant);
+        TermListDTO termListDTO = termService.getTermsByInitial(page, consonant, currentUser.getId());
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.from(TermListResponse.toTermListResponse(termListDTO)));
@@ -55,10 +56,11 @@ public class TermController {
     @Operation(summary = "키워드 별 용어 조회", description = "키워드 별 용어를 조회합니다.")
     @GetMapping("/search/keyword")
     public ResponseEntity<ApiResponse<Object>> getTermsByKeyword(
+            final @AuthenticationPrincipal CustomUserDetails currentUser,
             final @RequestParam(required = false, defaultValue = "0") @PositiveOrZero int page,
             @RequestParam(value = "keyword", required = false) final String keyword) {
 
-        TermListDTO termListDTO = termService.getTermsByKeyword(page, keyword);
+        TermListDTO termListDTO = termService.getTermsByKeyword(page, keyword, currentUser.getId());
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.from(TermListResponse.toTermListResponse(termListDTO)));

--- a/src/main/java/com/ripple/BE/term/domain/Term.java
+++ b/src/main/java/com/ripple/BE/term/domain/Term.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -43,6 +44,8 @@ public class Term extends BaseEntity {
     @Setter
     @Column(name = "initial", nullable = false)
     private String initial;
+
+    @Setter @Transient private Boolean isScrapped;
 
     public static Term toTermEntity(final TermDTO termDTO) {
         return Term.builder()

--- a/src/main/java/com/ripple/BE/term/dto/TermDTO.java
+++ b/src/main/java/com/ripple/BE/term/dto/TermDTO.java
@@ -3,16 +3,22 @@ package com.ripple.BE.term.dto;
 import com.ripple.BE.term.domain.Term;
 import java.util.Map;
 
-public record TermDTO(Long id, String title, String description, String initial) {
+public record TermDTO(
+        Long id, String title, String description, String initial, Boolean isScraped) {
 
     private static final String TITLE = "용어";
     private static final String DESCRIPTION = "설명";
 
     public static TermDTO toTermDTO(final Map<String, String> excelData) {
-        return new TermDTO(null, excelData.get(TITLE), excelData.get(DESCRIPTION), null);
+        return new TermDTO(null, excelData.get(TITLE), excelData.get(DESCRIPTION), null, null);
     }
 
     public static TermDTO toTermDTO(final Term term) {
-        return new TermDTO(term.getId(), term.getTitle(), term.getDescription(), term.getInitial());
+        return new TermDTO(
+                term.getId(),
+                term.getTitle(),
+                term.getDescription(),
+                term.getInitial(),
+                term.getIsScrapped());
     }
 }

--- a/src/main/java/com/ripple/BE/term/dto/response/TermListResponse.java
+++ b/src/main/java/com/ripple/BE/term/dto/response/TermListResponse.java
@@ -3,11 +3,11 @@ package com.ripple.BE.term.dto.response;
 import com.ripple.BE.term.dto.TermListDTO;
 import java.util.List;
 
-public record TermListResponse(List<TermResponse> termList, int totalPage, int currentPage) {
+public record TermListResponse(List<TermPreviewResponse> termList, int totalPage, int currentPage) {
 
     public static TermListResponse toTermListResponse(TermListDTO termListDTO) {
         return new TermListResponse(
-                termListDTO.termList().stream().map(TermResponse::toTermResponse).toList(),
+                termListDTO.termList().stream().map(TermPreviewResponse::toTermPreviewResponse).toList(),
                 termListDTO.totalPage(),
                 termListDTO.currentPage());
     }

--- a/src/main/java/com/ripple/BE/term/dto/response/TermPreviewResponse.java
+++ b/src/main/java/com/ripple/BE/term/dto/response/TermPreviewResponse.java
@@ -1,0 +1,15 @@
+package com.ripple.BE.term.dto.response;
+
+import com.ripple.BE.term.dto.TermDTO;
+
+public record TermPreviewResponse(
+        Long termId, // 용어 ID
+        String termName, // 용어명
+        String termDescription, // 용어 설명
+        Boolean isScraped) {
+
+    public static TermPreviewResponse toTermPreviewResponse(final TermDTO termDTO) {
+        return new TermPreviewResponse(
+                termDTO.id(), termDTO.title(), termDTO.description(), termDTO.isScraped());
+    }
+}

--- a/src/main/java/com/ripple/BE/term/repository/TermRepositoryCustom.java
+++ b/src/main/java/com/ripple/BE/term/repository/TermRepositoryCustom.java
@@ -9,4 +9,6 @@ public interface TermRepositoryCustom {
     Page<Term> findByInitial(String initial, Pageable pageable);
 
     Page<Term> findByKeyword(String keyword, Pageable pageable);
+
+    Page<Term> searchTerms(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/ripple/BE/term/repository/TermRepositoryCustom.java
+++ b/src/main/java/com/ripple/BE/term/repository/TermRepositoryCustom.java
@@ -6,9 +6,9 @@ import org.springframework.data.domain.Pageable;
 
 public interface TermRepositoryCustom {
 
-    Page<Term> findByInitial(String initial, Pageable pageable);
+    Page<Term> findByInitial(String initial, Pageable pageable, long userId);
 
-    Page<Term> findByKeyword(String keyword, Pageable pageable);
+    Page<Term> findByKeyword(String keyword, Pageable pageable, long userId);
 
-    Page<Term> searchTerms(String keyword, Pageable pageable);
+    Page<Term> searchTerms(String keyword, Pageable pageable, long userId);
 }

--- a/src/main/java/com/ripple/BE/term/repository/TermRepositoryCustomImpl.java
+++ b/src/main/java/com/ripple/BE/term/repository/TermRepositoryCustomImpl.java
@@ -43,6 +43,22 @@ public class TermRepositoryCustomImpl implements TermRepositoryCustom {
         return PageableExecutionUtils.getPage(termList, pageable, countQuery::fetchOne);
     }
 
+    @Override
+    public Page<Term> searchTerms(String keyword, Pageable pageable) {
+        BooleanExpression predicate = null;
+
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            predicate =
+                    term.title.containsIgnoreCase(keyword).or(term.description.containsIgnoreCase(keyword));
+        }
+
+        List<Term> termList = getTermByPageable(pageable, predicate);
+
+        JPAQuery<Long> countQuery = queryFactory.select(term.count()).from(term).where(predicate);
+
+        return PageableExecutionUtils.getPage(termList, pageable, countQuery::fetchOne);
+    }
+
     private List<Term> getTermByPageable(Pageable pageable, BooleanExpression predicate) {
         return queryFactory
                 .selectFrom(term)

--- a/src/main/java/com/ripple/BE/term/repository/TermRepositoryCustomImpl.java
+++ b/src/main/java/com/ripple/BE/term/repository/TermRepositoryCustomImpl.java
@@ -1,10 +1,13 @@
 package com.ripple.BE.term.repository;
 
 import static com.ripple.BE.term.domain.QTerm.*;
+import static com.ripple.BE.term.domain.QTermScrap.*;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ripple.BE.term.domain.QTerm;
 import com.ripple.BE.term.domain.Term;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -18,10 +21,10 @@ public class TermRepositoryCustomImpl implements TermRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Term> findByInitial(String initial, Pageable pageable) {
+    public Page<Term> findByInitial(String initial, Pageable pageable, long userId) {
         BooleanExpression predicate = term.initial.startsWith(initial);
 
-        List<Term> termList = getTermByPageable(pageable, predicate);
+        List<Term> termList = getTermsWithScrapByPageable(pageable, predicate, userId);
 
         JPAQuery<Long> countQuery = queryFactory.select(term.count()).from(term).where(predicate);
 
@@ -29,14 +32,14 @@ public class TermRepositoryCustomImpl implements TermRepositoryCustom {
     }
 
     @Override
-    public Page<Term> findByKeyword(String keyword, Pageable pageable) {
+    public Page<Term> findByKeyword(String keyword, Pageable pageable, long userId) {
         BooleanExpression predicate = null;
 
         if (keyword != null && !keyword.trim().isEmpty()) {
             predicate = term.title.containsIgnoreCase(keyword);
         }
 
-        List<Term> termList = getTermByPageable(pageable, predicate);
+        List<Term> termList = getTermsWithScrapByPageable(pageable, predicate, userId);
 
         JPAQuery<Long> countQuery = queryFactory.select(term.count()).from(term).where(predicate);
 
@@ -44,7 +47,7 @@ public class TermRepositoryCustomImpl implements TermRepositoryCustom {
     }
 
     @Override
-    public Page<Term> searchTerms(String keyword, Pageable pageable) {
+    public Page<Term> searchTerms(String keyword, Pageable pageable, long userId) {
         BooleanExpression predicate = null;
 
         if (keyword != null && !keyword.trim().isEmpty()) {
@@ -52,19 +55,36 @@ public class TermRepositoryCustomImpl implements TermRepositoryCustom {
                     term.title.containsIgnoreCase(keyword).or(term.description.containsIgnoreCase(keyword));
         }
 
-        List<Term> termList = getTermByPageable(pageable, predicate);
+        List<Term> termList = getTermsWithScrapByPageable(pageable, predicate, userId);
 
         JPAQuery<Long> countQuery = queryFactory.select(term.count()).from(term).where(predicate);
 
         return PageableExecutionUtils.getPage(termList, pageable, countQuery::fetchOne);
     }
 
-    private List<Term> getTermByPageable(Pageable pageable, BooleanExpression predicate) {
-        return queryFactory
-                .selectFrom(term)
-                .where(predicate)
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+    private List<Term> getTermsWithScrapByPageable(
+            Pageable pageable, BooleanExpression predicate, long userId) {
+
+        // 쿼리 실행: 스크랩 여부를 포함하여 데이터를 한 번에 가져옴
+        List<Tuple> results =
+                queryFactory
+                        .select(term, termScrap.id)
+                        .from(term)
+                        .leftJoin(termScrap)
+                        .on(term.id.eq(termScrap.term.id).and(termScrap.user.id.eq(userId)))
+                        .where(predicate)
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch();
+
+        return results.stream()
+                .map(
+                        tuple -> {
+                            Term term = tuple.get(QTerm.term);
+                            Long scrapId = tuple.get(termScrap.id);
+                            term.setIsScrapped(scrapId != null);
+                            return term;
+                        })
+                .toList();
     }
 }

--- a/src/main/java/com/ripple/BE/term/service/TermService.java
+++ b/src/main/java/com/ripple/BE/term/service/TermService.java
@@ -32,19 +32,19 @@ public class TermService {
 
     private static final int PAGE_SIZE = 10;
 
-    public TermListDTO getTermsByInitial(final int page, final String consonant) {
+    public TermListDTO getTermsByInitial(final int page, final String consonant, final long userId) {
 
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
 
-        Page<Term> terms = termRepository.findByInitial(consonant, pageable);
+        Page<Term> terms = termRepository.findByInitial(consonant, pageable, userId);
 
         return TermListDTO.toTermListDTO(terms);
     }
 
-    public TermListDTO getTermsByKeyword(final int page, final String keyword) {
+    public TermListDTO getTermsByKeyword(final int page, final String keyword, final long userId) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
 
-        Page<Term> terms = termRepository.findByKeyword(keyword, pageable);
+        Page<Term> terms = termRepository.findByKeyword(keyword, pageable, userId);
 
         return TermListDTO.toTermListDTO(terms);
     }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,6 +17,7 @@ spring:
     properties:
       hibernate:
         format_sql: false
+        default_batch_fetch_size: 100
   data:
     redis:
       host: localhost

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,6 +17,7 @@ spring:
     properties:
       hibernate:
         format_sql: false
+        default_batch_fetch_size: 50
   data:
     redis:
       host: ${REDIS_HOST}


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #35 

## 📝작업 내용

### 게시물, 뉴스, 용어 사전 검색 기능 구현
- 키워드 별 검색을 Querydsl 처리, 제목이나 내용에 키워드가 포함함될 경우 결과값에 추가
- 자주 조회되는 키워드나 api의 경우 DB 접근 최소화를 위해 캐싱 기능 설정
- 캐싱된 데이터는 동기화를 위해 1분 주기로 만료

<img width="733" alt="image" src="https://github.com/user-attachments/assets/99c588e6-07b1-476f-a244-2f9387372670" />

### 최근 검색어 조회 및 삭제 기능 구현
- 검색 api 호출 시 keyword를 입력받아 Redis에 저장
- 사용자별로 최대 20개 저장되면 만료기간은 7일

<img width="842" alt="image" src="https://github.com/user-attachments/assets/560d9b39-5cd9-4bdf-a31b-1660f9f611d1" />


### 뉴스 및 게시물 데이터 캐싱 적용
<img width="860" alt="image" src="https://github.com/user-attachments/assets/5bc091aa-01a9-402f-a1d4-aa45d0830bb8" />

### 목록 조회 시 사용자 스크랩 여부 추가
<img width="412" alt="image" src="https://github.com/user-attachments/assets/35ed76d2-dcb8-499a-a2e4-f9d51d1729c3" />

- Term, News, Post 엔터티에 DB에 저장되지 않는 @Transient 스크랩 여부 확인 필드 추가

<img width="689" alt="image" src="https://github.com/user-attachments/assets/6f408c1d-f166-4fa5-9262-91236f6abb3c" />

- 목록 조회 시 Scrap 엔터티랑 조인, 스크랩 엔터티 join 여부에 따라 필드 true, false 여부 설정


### 기본 Batch Size 조정
<img width="310" alt="image" src="https://github.com/user-attachments/assets/d6865eb5-b511-497e-8ef1-a22b7b5b7fbc" />

- 쿼리 대량 발생 방지 위해 기본 Batch Size 조정


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?