### PR TITLE
[Feat] 카카오 로그인 방식 변경 (#12)

### DIFF
--- a/src/main/java/com/ripple/BE/auth/client/KakaoApiClient.java
+++ b/src/main/java/com/ripple/BE/auth/client/KakaoApiClient.java
@@ -43,6 +43,7 @@ public class KakaoApiClient { // kakao API를 호출하기 위한 전용 class
                             .bodyToMono(KakaoTokenResponse.class)
                             .block();
 
+            log.info("🟢 Kakao API returned Access Token: {}", response.accessToken()); // 🔹 로그 추가
             return response.accessToken();
 
         } catch (WebClientResponseException e) {
@@ -52,11 +53,16 @@ public class KakaoApiClient { // kakao API를 호출하기 위한 전용 class
 
     // 카카오 API 호출 : Access Token -> 사용자 정보 조회
     public KakaoUserInfoResponse getUserInfo(String token) {
+        if (token == null || token.isBlank()) {
+            throw new RuntimeException("Token is null");
+        }
         try {
             return webClient
                     .get()
                     .uri(USER_INFO_URI)
-                    .header("Authorization", "Bearer " + token)
+                    .header("Authorization", "Bearer " + token.trim())
+                    .header("Content-Type", "application/json")
+                    .header("Accept", "application/json")
                     .retrieve()
                     .bodyToMono(KakaoUserInfoResponse.class)
                     .block();

--- a/src/main/java/com/ripple/BE/auth/controller/AuthControllerV2.java
+++ b/src/main/java/com/ripple/BE/auth/controller/AuthControllerV2.java
@@ -24,7 +24,8 @@ public class AuthControllerV2 {
     @GetMapping("/login/kakao")
     public ResponseEntity<ApiResponse<Object>> kakaoLogin(@RequestParam String accessToken) {
 
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(ApiResponse.from(authService.kakaoLoginV2(accessToken)));
+        String jwtToken = authService.kakaoLoginV2(accessToken);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(jwtToken));
     }
 }

--- a/src/main/java/com/ripple/BE/auth/controller/AuthControllerV2.java
+++ b/src/main/java/com/ripple/BE/auth/controller/AuthControllerV2.java
@@ -1,0 +1,30 @@
+package com.ripple.BE.auth.controller;
+
+import com.ripple.BE.auth.service.AuthService;
+import com.ripple.BE.global.dto.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v2/auth")
+@Tag(name = "Auth V2", description = "인증 API (v2)")
+public class AuthControllerV2 {
+
+    private final AuthService authService;
+
+    @Operation(summary = "카카오 로그인 (v2)", description = "네이티브 앱에서 카카오 로그인을 진행합니다.")
+    @GetMapping("/login/kakao")
+    public ResponseEntity<ApiResponse<Object>> kakaoLogin(@RequestParam String accessToken) {
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.from(authService.kakaoLoginV2(accessToken)));
+    }
+}

--- a/src/main/java/com/ripple/BE/auth/service/AuthService.java
+++ b/src/main/java/com/ripple/BE/auth/service/AuthService.java
@@ -35,6 +35,13 @@ public class AuthService {
     }
 
     @Transactional
+    public String kakaoLoginV2(String accessToken) {
+        Long userId = isSignedUp(accessToken); // Access Token을 이용해 사용자 정보를 가져오고 없으면 회원가입
+
+        return jwtTokenProvider.createToken(userId.toString()); // JWT 토큰 생성 및 반환
+    }
+
+    @Transactional
     public Long isSignedUp(String token) {
         KakaoUserInfoResponse userInfo = kakaoApiClient.getUserInfo(token);
         return userService.findOrCreateUser(userInfo);

--- a/src/main/java/com/ripple/BE/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/ripple/BE/global/config/WebSecurityConfig.java
@@ -42,7 +42,7 @@ public class WebSecurityConfig {
                                 authorize
                                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
                                         .permitAll() // Swagger 경로는 누구나 접근 가능
-                                        .requestMatchers("/api/v1/auth/**", "/api/v1/level-test/quiz")
+                                        .requestMatchers("/api/v1/auth/**", "/api/v1/level-test/quiz", "api/v2/auth/**")
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated() // 그 외의 경로는 인증된 사용자만 접근 가능

--- a/src/main/java/com/ripple/BE/user/domain/User.java
+++ b/src/main/java/com/ripple/BE/user/domain/User.java
@@ -68,11 +68,11 @@ public class User extends BaseEntity {
     private String nickname;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "business_type")
+    @Column(name = "business_type", length = 50)
     private BusinessType businessType; // 업종
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "job")
+    @Column(name = "job", length = 50)
     private Job job; // 직무
 
     @Column(name = "birthdate")
@@ -183,8 +183,8 @@ public class User extends BaseEntity {
 
     public void updateProfile(UpdateUserProfileRequest request) {
         this.nickname = request.nickname();
-        this.businessType = BusinessType.valueOf(request.businessType());
-        this.job = Job.valueOf(request.job());
+        this.businessType = BusinessType.from(request.businessType());
+        this.job = Job.from(request.job());
         this.birthDate = request.birthDate();
         this.gender = request.gender();
         this.profileIntro = request.profileIntro();

--- a/src/main/java/com/ripple/BE/user/domain/User.java
+++ b/src/main/java/com/ripple/BE/user/domain/User.java
@@ -11,7 +11,6 @@ import com.ripple.BE.post.domain.Post;
 import com.ripple.BE.post.domain.PostLike;
 import com.ripple.BE.post.domain.PostScrap;
 import com.ripple.BE.term.domain.TermScrap;
-import com.ripple.BE.user.domain.type.AgeRange;
 import com.ripple.BE.user.domain.type.BusinessType;
 import com.ripple.BE.user.domain.type.Gender;
 import com.ripple.BE.user.domain.type.Job;
@@ -32,6 +31,7 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -75,9 +75,8 @@ public class User extends BaseEntity {
     @Column(name = "job")
     private Job job; // 직무
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "age_range")
-    private AgeRange ageRange; // 연령대
+    @Column(name = "birthdate")
+    private Date birthDate; // 연령대
 
     @Enumerated(EnumType.STRING)
     @Column(name = "gender")
@@ -184,9 +183,9 @@ public class User extends BaseEntity {
 
     public void updateProfile(UpdateUserProfileRequest request) {
         this.nickname = request.nickname();
-        this.businessType = request.businessType();
-        this.job = request.job();
-        this.ageRange = request.ageRange();
+        this.businessType = BusinessType.valueOf(request.businessType());
+        this.job = Job.valueOf(request.job());
+        this.birthDate = request.birthDate();
         this.gender = request.gender();
         this.profileIntro = request.profileIntro();
         this.isLearningAlarmAllowed = request.isLearningAlarmAllowed();

--- a/src/main/java/com/ripple/BE/user/domain/type/BusinessType.java
+++ b/src/main/java/com/ripple/BE/user/domain/type/BusinessType.java
@@ -1,3 +1,44 @@
 package com.ripple.BE.user.domain.type;
 
-public enum BusinessType {}
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum BusinessType {
+    FINANCE_INSURANCE("금융/보험"),
+    IT_SOFTWARE("IT/소프트웨어"),
+    ELECTRONICS_SEMICONDUCTOR("전자/반도체"),
+    MANUFACTURING("제조업"),
+    CONSTRUCTION_REAL_ESTATE("건설/부동산"),
+    HEALTHCARE_PHARMACEUTICALS("의료/제약"),
+    EDUCATION_PUBLISHING("교육/출판"),
+    RETAIL_LOGISTICS("유통/물류"),
+    ENERGY_ENVIRONMENT("에너지/환경"),
+    AGRICULTURE_LIVESTOCK("농업/축산업"),
+    MEDIA_ADVERTISING("미디어/광고"),
+    TRAVEL_TOURISM("여행/관광"),
+    GOVERNMENT_NPO("공공기관/비영리단체"),
+    STARTUP_VENTURE("스타트업/벤처"),
+    OTHER("기타");
+
+    private final String description;
+
+    BusinessType(String description) {
+        this.description = description;
+    }
+
+    @JsonValue // JSON 응답 시 한글 반환
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonCreator // JSON 요청 시 한글 값을 Enum으로 변환
+    public static BusinessType from(String value) {
+        return Arrays.stream(BusinessType.values())
+                .filter(businessType -> businessType.description.equals(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 업종: " + value));
+    }
+}

--- a/src/main/java/com/ripple/BE/user/domain/type/BusinessType.java
+++ b/src/main/java/com/ripple/BE/user/domain/type/BusinessType.java
@@ -1,7 +1,3 @@
 package com.ripple.BE.user.domain.type;
 
-public enum BusinessType {
-    MARKETING,
-    RECRUITMENT,
-    DESIGN
-}
+public enum BusinessType {}

--- a/src/main/java/com/ripple/BE/user/domain/type/Job.java
+++ b/src/main/java/com/ripple/BE/user/domain/type/Job.java
@@ -1,7 +1,65 @@
 package com.ripple.BE.user.domain.type;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
 public enum Job {
-    DEVELOPER,
-    DESIGNER,
-    ENGINEER
+    // 전문직
+    DOCTOR_NURSE_HEALTHCARE("의사/간호사/보건의료"),
+    LAWYER_LEGAL("변호사/법무사"),
+    ACCOUNTANT_TAX_CONSULTANT("회계사/세무사"),
+    TEACHER_INSTRUCTOR("교사/강사"),
+    RESEARCHER_PROFESSOR("연구원/교수"),
+
+    // 기업/사무직
+    PLANNING_STRATEGY("기획/전략"),
+    MARKETING_ADVERTISING_PR("마케팅/광고/홍보"),
+    SALES_BUSINESS_DEVELOPMENT("영업/판매"),
+    FINANCE_ACCOUNTING("재무/회계"),
+    HR_TRAINING("인사/교육"),
+    CUSTOMER_SERVICE_SUPPORT("고객 서비스/상담"),
+    LEGAL_AUDIT("법무/감사"),
+
+    // IT/기술
+    DEVELOPER_FRONTEND_BACKEND("개발자(프론트엔드/백엔드)"),
+    DATA_ANALYST_ENGINEER("데이터 분석/엔지니어"),
+    UI_UX_DESIGNER("UI/UX 디자이너"),
+    NETWORK_SECURITY_EXPERT("네트워크/보안 전문가"),
+    IT_MANAGER("IT 관리자"),
+    CONSTRUCTION_CIVIL_ENGINEERING("건설/토목/설계"),
+    RESEARCH_DEVELOPMENT("연구개발(R&D)"),
+
+    // 서비스/창업
+    FOOD_SERVICE_CHEF("외식업/요리사"),
+    TRAVEL_PLANNER("관광/여행 플래너"),
+    STARTUP_ENTREPRENEUR("창업/스타트업 운영자"),
+    FREELANCER("프리랜서"),
+
+    // 기타
+    PUBLIC_ADMINISTRATION_OFFICIAL("공공/행정직 공무원"),
+    MILITARY_POLICE_FIRE_OFFICER("군인/경찰/소방관"),
+    ENTERTAINER_ARTIST("엔터테이너/예술가"),
+    OTHER("기타");
+
+    private final String description;
+
+    Job(String description) {
+        this.description = description;
+    }
+
+    @JsonValue
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonCreator
+    public static Job from(String value) {
+        return Arrays.stream(Job.values())
+                .filter(job -> job.description.equals(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 직무: " + value));
+    }
 }

--- a/src/main/java/com/ripple/BE/user/dto/UpdateUserProfileRequest.java
+++ b/src/main/java/com/ripple/BE/user/dto/UpdateUserProfileRequest.java
@@ -1,16 +1,14 @@
 package com.ripple.BE.user.dto;
 
-import com.ripple.BE.user.domain.type.AgeRange;
-import com.ripple.BE.user.domain.type.BusinessType;
 import com.ripple.BE.user.domain.type.Gender;
-import com.ripple.BE.user.domain.type.Job;
 import jakarta.validation.constraints.NotNull;
+import java.util.Date;
 
 public record UpdateUserProfileRequest(
         @NotNull String nickname,
-        @NotNull BusinessType businessType,
-        @NotNull Job job,
-        @NotNull AgeRange ageRange,
+        @NotNull String businessType,
+        @NotNull String job,
+        @NotNull Date birthDate,
         Gender gender,
         String profileIntro,
         Boolean isLearningAlarmAllowed,

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,9 +5,9 @@ spring:
       on-profile: local
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${DB_URL}
-    username: ${DB_USER}
-    password: ${DB_PASS}
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USER}
+    password: ${LOCAL_DB_PASS}
   jpa:
     database: mysql
     database-platform: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
## #️⃣연관된 이슈

>#12 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

카카오 로그인 v2
- 네이티브 앱 환경에서 카카오 로그인을 위한 코드를 작성
- api/v2/auth/login/kakao로 컨트롤러 따로 작성
- 시큐리티에 경로 추가 완료

유저 프로필 입력 관련 수정
- 연령대 > 생년월일로 대체
- 업종, 직무 String으로 받아서 enum 변환 후 저장


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?