### PR TITLE
[Feat] 알림 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,13 @@ dependencies {
     // amazon s3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+    // JACKSON
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    // SSE
+    implementation 'org.springframework.boot:spring-boot-starter-web-services'
+
 }
 
 clean {	delete file('src/main/generated')}

--- a/src/main/java/com/ripple/BE/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/ripple/BE/global/exception/handler/GlobalExceptionHandler.java
@@ -9,13 +9,16 @@ import com.ripple.BE.image.exception.ImageException;
 import com.ripple.BE.learning.exception.LearningException;
 import com.ripple.BE.learning.exception.QuizException;
 import com.ripple.BE.news.exception.NewsException;
+import com.ripple.BE.notification.exception.NotificationException;
 import com.ripple.BE.post.exception.PostException;
 import com.ripple.BE.term.exception.TermException;
 import com.ripple.BE.user.exception.UserException;
 import io.micrometer.common.lang.NonNull;
 import java.util.List;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -63,9 +66,15 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      * @return 처리된 예외 응답
      */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<Object> handleAllException(Exception e) {
-        e.printStackTrace(); // 터미널에 에러 메시지 출력
-        logger.error("Exception occurred:" + e.getMessage() + e); // 로그에 에러 메시지 출력
+    public ResponseEntity<Object> handleAllException(Exception e, WebRequest request) {
+        String contentType = request.getHeader("Accept");
+
+        // SSE 요청일 경우 빈 응답 또는 연결 닫기 처리
+        if (MediaType.TEXT_EVENT_STREAM_VALUE.equals(contentType)) {
+            logger.error("SSE 요청 중 예외 발생");
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
         return handleExceptionInternal(GlobalErrorCode.INTERNAL_SERVER_ERROR);
     }
 
@@ -101,6 +110,11 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(ImageException.class)
     public ResponseEntity<Object> handleImageException(final ImageException e) {
+        return handleExceptionInternal(e.getErrorCode());
+    }
+
+    @ExceptionHandler(NotificationException.class)
+    public ResponseEntity<Object> handleNotificationException(final NotificationException e) {
         return handleExceptionInternal(e.getErrorCode());
     }
 

--- a/src/main/java/com/ripple/BE/notification/controller/NotificationController.java
+++ b/src/main/java/com/ripple/BE/notification/controller/NotificationController.java
@@ -1,0 +1,88 @@
+package com.ripple.BE.notification.controller;
+
+import com.ripple.BE.global.dto.response.ApiResponse;
+import com.ripple.BE.notification.dto.NotificationListDTO;
+import com.ripple.BE.notification.dto.response.NotificationListResponse;
+import com.ripple.BE.notification.dto.response.UnreadCountResponse;
+import com.ripple.BE.notification.service.NotificationService;
+import com.ripple.BE.notification.service.SseEmitterManager;
+import com.ripple.BE.user.domain.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/notification")
+@Tag(name = "Notification", description = "알림 관련 API")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+    private final SseEmitterManager sseEmitterManager;
+
+    @Operation(summary = "알림 구독", description = "알림 구독을 위한 SseEmitter 생성")
+    @GetMapping(path = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(
+            final @AuthenticationPrincipal CustomUserDetails currentUser,
+            final @RequestHeader(name = "Last-Event-ID", required = false) String lastEventId) {
+
+        return sseEmitterManager.subscribe(currentUser.getId(), lastEventId);
+    }
+
+    @Operation(summary = "알림 삭제", description = "알림을 삭제합니다.")
+    @DeleteMapping("/{notificationId}")
+    public ResponseEntity<ApiResponse<Object>> deleteNotification(
+            final @PathVariable("notificationId") long notificationId) {
+
+        notificationService.deleteNotification(notificationId);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
+    }
+
+    @Operation(summary = "알림 조회", description = "알림을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<Object>> getNotificationList(
+            final @AuthenticationPrincipal CustomUserDetails currentUser) {
+
+        NotificationListDTO notificationListDTO =
+                notificationService.getNotifications(currentUser.getId());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(
+                        ApiResponse.from(
+                                NotificationListResponse.toNotificationListResponse(notificationListDTO)));
+    }
+
+    @Operation(summary = "알림 확인", description = "알림을 확인합니다.")
+    @PostMapping("/{notificationId}/check")
+    public ResponseEntity<ApiResponse<Object>> checkNotification(
+            final @PathVariable("notificationId") long notificationId) {
+
+        notificationService.markAsRead(notificationId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
+    }
+
+    @Operation(summary = "읽지 않은 알림 개수 조회", description = "읽지 않은 알림 개수를 조회합니다.")
+    @GetMapping("/unread-count")
+    public ResponseEntity<ApiResponse<Object>> getUnreadNotificationCount(
+            final @AuthenticationPrincipal CustomUserDetails currentUser) {
+
+        long unreadNotificationCount =
+                notificationService.getUnreadNotificationCount(currentUser.getId());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.from(UnreadCountResponse.toUnreadCountResponse(unreadNotificationCount)));
+    }
+}

--- a/src/main/java/com/ripple/BE/notification/controller/NotificationController.java
+++ b/src/main/java/com/ripple/BE/notification/controller/NotificationController.java
@@ -32,7 +32,10 @@ public class NotificationController {
     private final NotificationService notificationService;
     private final SseEmitterManager sseEmitterManager;
 
-    @Operation(summary = "알림 구독", description = "알림 구독을 위한 SseEmitter 생성")
+    @Operation(
+            summary = "알림 구독",
+            description =
+                    "알림 구독을 위한 SseEmitter 생성, 푸시 알림을 받기 전에 이 API를 호출해야 합니다. 연결 종료로 인해 푸시 알림을 받지 못한 경우, Last-Event-ID 헤더를 통해 마지막으로 수신한 이벤트 ID를 전달하여 누락된 이벤트를 재전송받을 수 있습니다.")
     @GetMapping(path = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(
             final @AuthenticationPrincipal CustomUserDetails currentUser,

--- a/src/main/java/com/ripple/BE/notification/domain/Notification.java
+++ b/src/main/java/com/ripple/BE/notification/domain/Notification.java
@@ -1,0 +1,75 @@
+package com.ripple.BE.notification.domain;
+
+import com.ripple.BE.global.entity.BaseEntity;
+import com.ripple.BE.post.domain.Post;
+import com.ripple.BE.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Table(name = "notification")
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User receiver;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    // 알림 유형 (예: 댓글, 대댓글, 좋아요 등)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private NotificationType type;
+
+    @Setter
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead = false;
+
+    public static Notification toNotificationEntity(
+            final User receiver,
+            final String content,
+            final String title,
+            final NotificationType type,
+            final Post post) {
+
+        return Notification.builder()
+                .receiver(receiver)
+                .content(content)
+                .title(title)
+                .post(post)
+                .type(type)
+                .build();
+    }
+}

--- a/src/main/java/com/ripple/BE/notification/domain/NotificationType.java
+++ b/src/main/java/com/ripple/BE/notification/domain/NotificationType.java
@@ -1,0 +1,14 @@
+package com.ripple.BE.notification.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationType {
+    COMMENT("댓글"),
+    REPLY("대댓글"),
+    POPULAR("인기글");
+
+    private final String notificationType;
+}

--- a/src/main/java/com/ripple/BE/notification/dto/NotificationDTO.java
+++ b/src/main/java/com/ripple/BE/notification/dto/NotificationDTO.java
@@ -1,0 +1,32 @@
+package com.ripple.BE.notification.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.ripple.BE.notification.domain.Notification;
+import com.ripple.BE.notification.domain.NotificationType;
+import java.time.LocalDateTime;
+
+public record NotificationDTO(
+        Long id,
+        String title,
+        String content,
+        boolean isRead,
+        NotificationType type,
+        long postId,
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+                @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+                LocalDateTime createdDate) {
+
+    public static NotificationDTO toNotificationDTO(final Notification notification) {
+        return new NotificationDTO(
+                notification.getId(),
+                notification.getTitle(),
+                notification.getContent(),
+                notification.isRead(),
+                notification.getType(),
+                notification.getPost().getId(),
+                notification.getCreatedDate());
+    }
+}

--- a/src/main/java/com/ripple/BE/notification/dto/NotificationListDTO.java
+++ b/src/main/java/com/ripple/BE/notification/dto/NotificationListDTO.java
@@ -1,0 +1,13 @@
+package com.ripple.BE.notification.dto;
+
+import com.ripple.BE.notification.domain.Notification;
+import java.util.List;
+
+public record NotificationListDTO(List<NotificationDTO> notificationDTOList) {
+
+    public static NotificationListDTO toNotificationListDTO(
+            final List<Notification> notificationList) {
+        return new NotificationListDTO(
+                notificationList.stream().map(NotificationDTO::toNotificationDTO).toList());
+    }
+}

--- a/src/main/java/com/ripple/BE/notification/dto/response/NotificationListResponse.java
+++ b/src/main/java/com/ripple/BE/notification/dto/response/NotificationListResponse.java
@@ -1,0 +1,15 @@
+package com.ripple.BE.notification.dto.response;
+
+import com.ripple.BE.notification.dto.NotificationListDTO;
+import java.util.List;
+
+public record NotificationListResponse(List<NotificationResponse> notificationResponseList) {
+
+    public static NotificationListResponse toNotificationListResponse(
+            final NotificationListDTO notificationListDTO) {
+        return new NotificationListResponse(
+                notificationListDTO.notificationDTOList().stream()
+                        .map(NotificationResponse::toNotificationResponse)
+                        .toList());
+    }
+}

--- a/src/main/java/com/ripple/BE/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/ripple/BE/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,26 @@
+package com.ripple.BE.notification.dto.response;
+
+import com.ripple.BE.global.utils.RelativeTimeFormatter;
+import com.ripple.BE.notification.domain.NotificationType;
+import com.ripple.BE.notification.dto.NotificationDTO;
+
+public record NotificationResponse(
+        Long id,
+        String postTitle,
+        String content,
+        boolean isRead,
+        NotificationType type,
+        long postId,
+        String createdDate) {
+
+    public static NotificationResponse toNotificationResponse(NotificationDTO notificationDTO) {
+        return new NotificationResponse(
+                notificationDTO.id(),
+                notificationDTO.title(),
+                notificationDTO.content(),
+                notificationDTO.isRead(),
+                notificationDTO.type(),
+                notificationDTO.postId(),
+                RelativeTimeFormatter.formatRelativeTime(notificationDTO.createdDate()));
+    }
+}

--- a/src/main/java/com/ripple/BE/notification/dto/response/UnreadCountResponse.java
+++ b/src/main/java/com/ripple/BE/notification/dto/response/UnreadCountResponse.java
@@ -1,0 +1,7 @@
+package com.ripple.BE.notification.dto.response;
+
+public record UnreadCountResponse(long unreadCount) {
+    public static UnreadCountResponse toUnreadCountResponse(final long unreadCount) {
+        return new UnreadCountResponse(unreadCount);
+    }
+}

--- a/src/main/java/com/ripple/BE/notification/exception/NotificationException.java
+++ b/src/main/java/com/ripple/BE/notification/exception/NotificationException.java
@@ -1,0 +1,12 @@
+package com.ripple.BE.notification.exception;
+
+import com.ripple.BE.notification.exception.errorcode.NotificationErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class NotificationException extends RuntimeException {
+
+    private final NotificationErrorCode errorCode;
+}

--- a/src/main/java/com/ripple/BE/notification/exception/errorcode/NotificationErrorCode.java
+++ b/src/main/java/com/ripple/BE/notification/exception/errorcode/NotificationErrorCode.java
@@ -1,0 +1,17 @@
+package com.ripple.BE.notification.exception.errorcode;
+
+import com.ripple.BE.global.exception.errorcode.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationErrorCode implements ErrorCode {
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "Notification not found"),
+    NOTIFICATION_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/ripple/BE/notification/repository/EmitterRepository.java
+++ b/src/main/java/com/ripple/BE/notification/repository/EmitterRepository.java
@@ -37,15 +37,19 @@ public class EmitterRepository {
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    public void deleteEmitterById(String id) {
+    public void deleteEmitterById(final String id) {
         emitters.remove(id);
     }
 
-    public void deleteAllEmitterById(String id) {
-        emitters.keySet().removeIf(key -> key.startsWith(id));
+    public void deleteAllEmitterById(final long userId) {
+        String idStr = String.valueOf(userId);
+
+        emitters.keySet().removeIf(key -> key.startsWith(idStr));
     }
 
-    public void deleteAllEventCacheById(String id) {
-        eventCache.keySet().removeIf(key -> key.startsWith(id));
+    public void deleteAllEventCacheById(final long userId) {
+        String idStr = String.valueOf(userId);
+
+        eventCache.keySet().removeIf(key -> key.startsWith(idStr));
     }
 }

--- a/src/main/java/com/ripple/BE/notification/repository/EmitterRepository.java
+++ b/src/main/java/com/ripple/BE/notification/repository/EmitterRepository.java
@@ -1,0 +1,51 @@
+package com.ripple.BE.notification.repository;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+public class EmitterRepository {
+
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
+
+    public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
+        emitters.put(emitterId, sseEmitter);
+        return sseEmitter;
+    }
+
+    public void saveEventCache(String eventCacheId, Object event) {
+        eventCache.put(eventCacheId, event);
+    }
+
+    public Map<String, SseEmitter> findAllEmitterByUserId(final long userId) {
+        String userIdStr = String.valueOf(userId);
+
+        return emitters.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(userIdStr))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public Map<String, Object> findAllEventCacheByUserId(final long userId) {
+        String userIdStr = String.valueOf(userId);
+
+        return eventCache.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(userIdStr))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public void deleteEmitterById(String id) {
+        emitters.remove(id);
+    }
+
+    public void deleteAllEmitterById(String id) {
+        emitters.keySet().removeIf(key -> key.startsWith(id));
+    }
+
+    public void deleteAllEventCacheById(String id) {
+        eventCache.keySet().removeIf(key -> key.startsWith(id));
+    }
+}

--- a/src/main/java/com/ripple/BE/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ripple/BE/notification/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.ripple.BE.notification.repository;
+
+import com.ripple.BE.notification.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository
+        extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {}

--- a/src/main/java/com/ripple/BE/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/com/ripple/BE/notification/repository/NotificationRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.ripple.BE.notification.repository;
+
+import com.ripple.BE.notification.domain.Notification;
+import java.util.List;
+
+public interface NotificationRepositoryCustom {
+
+    List<Notification> findByUserId(final long userId);
+
+    long countByUserIdAndIsReadFalse(final long userId);
+}

--- a/src/main/java/com/ripple/BE/notification/repository/NotificationRepositoryCustomImpl.java
+++ b/src/main/java/com/ripple/BE/notification/repository/NotificationRepositoryCustomImpl.java
@@ -1,0 +1,35 @@
+package com.ripple.BE.notification.repository;
+
+import static com.ripple.BE.notification.domain.QNotification.*;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ripple.BE.notification.domain.Notification;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class NotificationRepositoryCustomImpl implements NotificationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Notification> findByUserId(final long userId) {
+        return queryFactory
+                .selectFrom(notification)
+                .where(notification.receiver.id.eq(userId))
+                .orderBy(notification.createdDate.desc())
+                .fetch();
+    }
+
+    @Override
+    public long countByUserIdAndIsReadFalse(final long userId) {
+        Long count =
+                queryFactory
+                        .select(notification.count())
+                        .from(notification)
+                        .where(notification.receiver.id.eq(userId).and(notification.isRead.isFalse()))
+                        .fetchOne();
+
+        return count == null ? 0 : count;
+    }
+}

--- a/src/main/java/com/ripple/BE/notification/service/NotificationService.java
+++ b/src/main/java/com/ripple/BE/notification/service/NotificationService.java
@@ -47,17 +47,20 @@ public class NotificationService {
         User postAuthor = post.getAuthor();
         User commentAuthor = comment.getParent().getCommenter();
 
+        String content = comment.getContent();
+        String title = post.getTitle();
+
         Notification notificationForPostAuthor =
-                Notification.toNotificationEntity(
-                        postAuthor, comment.getContent(), post.getTitle(), NotificationType.REPLY, post);
+                Notification.toNotificationEntity(postAuthor, content, title, NotificationType.REPLY, post);
 
         Notification notificationForCommentAuthor =
                 Notification.toNotificationEntity(
-                        commentAuthor, comment.getContent(), post.getTitle(), NotificationType.REPLY, post);
+                        commentAuthor, content, title, NotificationType.REPLY, post);
 
         notificationRepository.save(notificationForPostAuthor);
         notificationRepository.save(notificationForCommentAuthor);
 
+        // 게시글 작성자와 댓글 작성자에게 알림 전송
         sendNotification(postAuthor, NotificationDTO.toNotificationDTO(notificationForPostAuthor));
         sendNotification(
                 commentAuthor, NotificationDTO.toNotificationDTO(notificationForCommentAuthor));
@@ -95,8 +98,6 @@ public class NotificationService {
                         .findById(notificationId)
                         .orElseThrow(() -> new NotificationException(NOTIFICATION_NOT_FOUND));
         notification.setRead(true);
-
-        notificationRepository.save(notification);
     }
 
     // 알림 삭제
@@ -108,7 +109,6 @@ public class NotificationService {
                         .orElseThrow(() -> new NotificationException(NOTIFICATION_NOT_FOUND));
 
         notificationRepository.delete(notification);
-        sseEmitterManager.deleteEmitter(notification.getReceiver().getId());
     }
 
     private void sendNotification(final User receiver, final NotificationDTO notification) {

--- a/src/main/java/com/ripple/BE/notification/service/NotificationService.java
+++ b/src/main/java/com/ripple/BE/notification/service/NotificationService.java
@@ -1,0 +1,119 @@
+package com.ripple.BE.notification.service;
+
+import static com.ripple.BE.notification.exception.errorcode.NotificationErrorCode.*;
+
+import com.ripple.BE.notification.domain.Notification;
+import com.ripple.BE.notification.domain.NotificationType;
+import com.ripple.BE.notification.dto.NotificationDTO;
+import com.ripple.BE.notification.dto.NotificationListDTO;
+import com.ripple.BE.notification.exception.NotificationException;
+import com.ripple.BE.notification.repository.NotificationRepository;
+import com.ripple.BE.post.domain.Comment;
+import com.ripple.BE.post.domain.Post;
+import com.ripple.BE.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+@Transactional(readOnly = true)
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final SseEmitterManager sseEmitterManager; // SSE 연결 관리 클래스
+
+    private static final String POPULAR_POST_CONTENT = "이 게시글이 인기글로 선정되었습니다.";
+
+    @Transactional
+    public void createCommentNotification(final Post post, final Comment comment) {
+
+        User postAuthor = post.getAuthor();
+
+        Notification notification =
+                Notification.toNotificationEntity(
+                        postAuthor, comment.getContent(), post.getTitle(), NotificationType.COMMENT, post);
+
+        notificationRepository.save(notification);
+
+        sendNotification(postAuthor, NotificationDTO.toNotificationDTO(notification));
+    }
+
+    @Transactional
+    public void createReplyNotification(final Post post, final Comment comment) {
+
+        User postAuthor = post.getAuthor();
+        User commentAuthor = comment.getParent().getCommenter();
+
+        Notification notificationForPostAuthor =
+                Notification.toNotificationEntity(
+                        postAuthor, comment.getContent(), post.getTitle(), NotificationType.REPLY, post);
+
+        Notification notificationForCommentAuthor =
+                Notification.toNotificationEntity(
+                        commentAuthor, comment.getContent(), post.getTitle(), NotificationType.REPLY, post);
+
+        notificationRepository.save(notificationForPostAuthor);
+        notificationRepository.save(notificationForCommentAuthor);
+
+        sendNotification(postAuthor, NotificationDTO.toNotificationDTO(notificationForPostAuthor));
+        sendNotification(
+                commentAuthor, NotificationDTO.toNotificationDTO(notificationForCommentAuthor));
+    }
+
+    @Transactional
+    public void createPopularNotification(final Post post) {
+
+        User receiver = post.getAuthor();
+
+        Notification notification =
+                Notification.toNotificationEntity(
+                        receiver, POPULAR_POST_CONTENT, post.getTitle(), NotificationType.POPULAR, post);
+
+        notificationRepository.save(notification);
+
+        sendNotification(receiver, NotificationDTO.toNotificationDTO(notification));
+    }
+
+    // 사용자 알림 목록 조회
+    public NotificationListDTO getNotifications(final long userId) {
+        return NotificationListDTO.toNotificationListDTO(notificationRepository.findByUserId(userId));
+    }
+
+    // 읽지 않은 알림 개수 조회
+    public long getUnreadNotificationCount(final long receiverId) {
+        return notificationRepository.countByUserIdAndIsReadFalse(receiverId);
+    }
+
+    // 알림 읽음 처리
+    @Transactional
+    public void markAsRead(final long notificationId) {
+        Notification notification =
+                notificationRepository
+                        .findById(notificationId)
+                        .orElseThrow(() -> new NotificationException(NOTIFICATION_NOT_FOUND));
+        notification.setRead(true);
+
+        notificationRepository.save(notification);
+    }
+
+    // 알림 삭제
+    @Transactional
+    public void deleteNotification(final long notificationId) {
+        Notification notification =
+                notificationRepository
+                        .findById(notificationId)
+                        .orElseThrow(() -> new NotificationException(NOTIFICATION_NOT_FOUND));
+
+        notificationRepository.delete(notification);
+        sseEmitterManager.deleteEmitter(notification.getReceiver().getId());
+    }
+
+    private void sendNotification(final User receiver, final NotificationDTO notification) {
+        if (receiver.isCoummunityAlarmAllowed()) {
+            sseEmitterManager.send(receiver, notification);
+        }
+    }
+}

--- a/src/main/java/com/ripple/BE/notification/service/SseEmitterManager.java
+++ b/src/main/java/com/ripple/BE/notification/service/SseEmitterManager.java
@@ -1,0 +1,104 @@
+package com.ripple.BE.notification.service;
+
+import static com.ripple.BE.notification.exception.errorcode.NotificationErrorCode.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ripple.BE.notification.dto.NotificationDTO;
+import com.ripple.BE.notification.repository.EmitterRepository;
+import com.ripple.BE.user.domain.User;
+import java.io.IOException;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SseEmitterManager {
+
+    private final EmitterRepository emitterRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public SseEmitter subscribe(final long userId, final String lastEventId) {
+
+        String emitterId = userId + "_" + System.currentTimeMillis();
+
+        SseEmitter sseEmitter = emitterRepository.save(emitterId, new SseEmitter(Long.MAX_VALUE));
+
+        // 상황별 emitter 삭제 처리
+        sseEmitter.onCompletion(() -> emitterRepository.deleteEmitterById(emitterId)); // 연결 종료 시
+        sseEmitter.onTimeout(() -> emitterRepository.deleteEmitterById(emitterId)); // 타임아웃 시
+        sseEmitter.onError((e) -> emitterRepository.deleteEmitterById(emitterId)); // 에러 발생 시
+
+        // 503 Service Unavailable 방지용 dummy event 전송
+        sendDummyEvent(sseEmitter, emitterId);
+
+        // client가 미수신한 event 목록이 존재하는 경우
+        if (lastEventId != null && !lastEventId.isEmpty()) {
+            Map<String, Object> eventCaches = emitterRepository.findAllEventCacheByUserId(userId);
+            eventCaches.entrySet().stream() // 미수신 상태인 event 목록 전송
+                    .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+                    .forEach(entry -> sendEventToClient(sseEmitter, entry.getKey(), entry.getValue()));
+        }
+
+        return sseEmitter;
+    }
+
+    public void send(User receiver, NotificationDTO data) {
+        String emitterId = null;
+
+        try {
+            Map<String, SseEmitter> emitters = emitterRepository.findAllEmitterByUserId(receiver.getId());
+
+            if (emitters.isEmpty()) {
+                return;
+            }
+
+            emitterId = emitters.keySet().iterator().next();
+
+            emitters.forEach(
+                    (key, value) -> {
+                        emitterRepository.saveEventCache(key, data);
+                        sendEventToClient(value, key, data);
+                    });
+        } catch (Exception e) {
+            emitterRepository.deleteEmitterById(emitterId);
+        }
+    }
+
+    private void sendEventToClient(SseEmitter sseEmitter, String emitterId, Object data) {
+        try {
+            String jsonData = objectMapper.writeValueAsString(data);
+            sseEmitter.send(
+                    SseEmitter.event()
+                            .id(emitterId)
+                            .name("notification")
+                            .data(jsonData, MediaType.APPLICATION_JSON));
+        } catch (IOException e) {
+            emitterRepository.deleteEmitterById(emitterId);
+            sseEmitter.completeWithError(e);
+        }
+    }
+
+    private void sendDummyEvent(SseEmitter sseEmitter, String emitterId) {
+        try {
+            sseEmitter.send(
+                    SseEmitter.event()
+                            .id(emitterId)
+                            .name("test")
+                            .data("Connection established", MediaType.APPLICATION_JSON));
+        } catch (IOException e) {
+            emitterRepository.deleteEmitterById(emitterId);
+            sseEmitter.completeWithError(e);
+        }
+    }
+
+    // 알림 삭제
+    public void deleteEmitter(final long userId) {
+        emitterRepository.deleteAllEmitterById(String.valueOf(userId));
+        emitterRepository.deleteAllEventCacheById(String.valueOf(userId));
+    }
+}

--- a/src/main/java/com/ripple/BE/notification/service/SseEmitterManager.java
+++ b/src/main/java/com/ripple/BE/notification/service/SseEmitterManager.java
@@ -1,7 +1,5 @@
 package com.ripple.BE.notification.service;
 
-import static com.ripple.BE.notification.exception.errorcode.NotificationErrorCode.*;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ripple.BE.notification.dto.NotificationDTO;
 import com.ripple.BE.notification.repository.EmitterRepository;
@@ -98,7 +96,7 @@ public class SseEmitterManager {
 
     // 알림 삭제
     public void deleteEmitter(final long userId) {
-        emitterRepository.deleteAllEmitterById(String.valueOf(userId));
-        emitterRepository.deleteAllEventCacheById(String.valueOf(userId));
+        emitterRepository.deleteAllEmitterById(userId);
+        emitterRepository.deleteAllEventCacheById(userId);
     }
 }

--- a/src/main/java/com/ripple/BE/post/service/PostService.java
+++ b/src/main/java/com/ripple/BE/post/service/PostService.java
@@ -7,6 +7,7 @@ import com.ripple.BE.image.domain.Image;
 import com.ripple.BE.image.exception.ImageException;
 import com.ripple.BE.image.repository.ImageRepository;
 import com.ripple.BE.image.service.ImageService;
+import com.ripple.BE.notification.service.NotificationService;
 import com.ripple.BE.post.domain.Comment;
 import com.ripple.BE.post.domain.CommentLike;
 import com.ripple.BE.post.domain.Post;
@@ -48,8 +49,10 @@ public class PostService {
 
     private final UserService userService;
     private final ImageService imageService;
+    private final NotificationService notificationService;
 
     private static final int PAGE_SIZE = 10;
+    private static final int POPULAR_POST_LIKE_COUNT = 10;
 
     @Transactional
     public void createPost(
@@ -163,6 +166,10 @@ public class PostService {
         postLike.setPost(post);
 
         post.increaseLikeCount();
+
+        if (post.getLikeCount() == POPULAR_POST_LIKE_COUNT) {
+            notificationService.createPopularNotification(post);
+        }
     }
 
     @Transactional
@@ -223,6 +230,8 @@ public class PostService {
         comment.setPost(post);
 
         post.increaseCommentCount();
+
+        notificationService.createCommentNotification(post, comment);
     }
 
     @Transactional
@@ -276,6 +285,8 @@ public class PostService {
 
         post.increaseCommentCount();
         parent.increaseReplyCount();
+
+        notificationService.createReplyNotification(post, comment);
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #36

## 📝작업 내용

### SseEmitter 생성 위한 알림 구독 기능 구현
- 서버에서 클라이언트로 일방향 전송 푸시 알림을 전송하기 위해서 SseEmitter 생성이 필요
- 클라이이트는 알림 수신 하기 전에 해당 api를 통해 요청해서 구독을 진행해야 함
   <img width="712" alt="image" src="https://github.com/user-attachments/assets/0b88b73b-f53d-4a44-8844-24d7ce8dd662" />
   <img width="775" alt="image" src="https://github.com/user-attachments/assets/4a7c057e-b02e-4b56-a847-ed3ddaecd46f" />

- 위 그림처럼 요청을 보내면 Text-Strem으로 계속 수신받을 수 있음

### 알림 전송 기능 구현
- SseEmitterManager를 통해 emitter 정보 저장 및 삭제 관리
   <img width="514" alt="image" src="https://github.com/user-attachments/assets/9d523a81-5396-4e8c-bd7d-51f8a8ae75cf" />

- 알림 전송 시 emitterId를 통해 emitter 조회 후 푸시 알림 전송
    <img width="683" alt="image" src="https://github.com/user-attachments/assets/1dda790c-cd27-45d4-a163-30ab0ef7fd47" />

- 댓글, 대댓글, 인기글 선정 시 알림 전송
   <img width="487" alt="image" src="https://github.com/user-attachments/assets/8999785a-e9bd-4d50-ba9f-94b46db29254" />

### 알림 조회 기능 구현
- userId를 통해 알림 엔터티 목록 조회
  <img width="790" alt="image" src="https://github.com/user-attachments/assets/201d20e9-72a6-498a-ad53-301cab10ba3e" />

### 읽지 않은 알림 개수 조회 기능 구현

### 알림 읽음 처리 기능 구현

### 알림 삭제 기능 구현

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?