### PR TITLE
[Feat] 푸시 알람 변경 기능, 레벨업, 목록 조회 api Getmapping으로 수정 

### DIFF
--- a/src/main/java/com/ripple/BE/learning/controller/LearningController.java
+++ b/src/main/java/com/ripple/BE/learning/controller/LearningController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,7 +34,7 @@ public class LearningController {
     }
 
     @Operation(summary = "레벨별 학습 세트 조회", description = "레벨별 전체 학습 세트를 조회합니다.")
-    @PostMapping
+    @GetMapping
     public ResponseEntity<ApiResponse<Object>> getLearningSets(
             final @AuthenticationPrincipal CustomUserDetails currentUser) {
 

--- a/src/main/java/com/ripple/BE/learning/service/concept/ConceptService.java
+++ b/src/main/java/com/ripple/BE/learning/service/concept/ConceptService.java
@@ -14,6 +14,7 @@ import com.ripple.BE.learning.repository.learningSet.UserLearningSetRepository;
 import com.ripple.BE.learning.service.learningset.LearningSetService;
 import com.ripple.BE.user.domain.User;
 import com.ripple.BE.user.domain.type.Level;
+import com.ripple.BE.user.service.UserProgressService;
 import com.ripple.BE.user.service.UserService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,7 @@ public class ConceptService {
 
     private final LearningSetService learningSetService;
     private final UserService userService;
+    private final UserProgressService userProgressService;
 
     private final UserLearningSetRepository userLearningSetRepository;
     private final ConceptRepository conceptRepository;
@@ -69,6 +71,8 @@ public class ConceptService {
         if (!userLearningSet.isConceptCompleted()) {
             userLearningSet.setConceptCompleted();
             userService.updateCompletedCountByLevel(user, level);
+
+            userProgressService.updateLevel(user);
         }
     }
 

--- a/src/main/java/com/ripple/BE/learning/service/quiz/QuizService.java
+++ b/src/main/java/com/ripple/BE/learning/service/quiz/QuizService.java
@@ -21,6 +21,7 @@ import com.ripple.BE.learning.repository.quizScrap.QuizScrapRepository;
 import com.ripple.BE.learning.service.learningset.LearningSetService;
 import com.ripple.BE.user.domain.User;
 import com.ripple.BE.user.domain.type.Level;
+import com.ripple.BE.user.service.UserProgressService;
 import com.ripple.BE.user.service.UserService;
 import java.util.Collections;
 import java.util.HashSet;
@@ -44,6 +45,7 @@ public class QuizService {
     private final QuizRedisService quizRedisService;
     private final LearningSetService learningSetService;
     private final UserService userService;
+    private final UserProgressService userProgressService;
 
     private static final String QUESTION_TYPE = "questions";
     private static final String WRONG_ANSWER_TYPE = "wrongAnswer";
@@ -138,6 +140,8 @@ public class QuizService {
             userLearningSet.setQuizCompleted(); // 퀴즈 완료 처리
             userService.updateUserStatsAfterQuiz(
                     user, level, failQuizList, quizCount, correctCount); // 사용자 통계 업데이트
+
+            userProgressService.updateLevel(user); // 레벨 업데이트
         }
 
         quizRedisService.clearRedisKeys(userId); // 퀴즈 진행 관련 데이터 삭제

--- a/src/main/java/com/ripple/BE/user/controller/UserController.java
+++ b/src/main/java/com/ripple/BE/user/controller/UserController.java
@@ -54,6 +54,16 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
     }
 
+    @Operation(summary = "푸시 알림 설정", description = "로그인 후 유저의 푸시 알림 설정을 변경합니다.")
+    @PostMapping("/alarm")
+    public ResponseEntity<ApiResponse<?>> alarm(
+            @RequestParam boolean alarm, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        userService.updateAlarm(alarm, customUserDetails.getId());
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
+    }
+
     @Operation(summary = "내가 쓴 게시물 조회", description = "로그인한 유저가 작성한 게시물을 조회합니다.")
     @GetMapping("/posts")
     public ResponseEntity<ApiResponse<Object>> getMyPosts(

--- a/src/main/java/com/ripple/BE/user/domain/User.java
+++ b/src/main/java/com/ripple/BE/user/domain/User.java
@@ -37,6 +37,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Table(name = "users")
 @Getter
@@ -99,6 +100,7 @@ public class User extends BaseEntity {
     @Column(name = "is_learning_alarm_allowed")
     private boolean isLearningAlarmAllowed = false; // 학습 푸시 알람 여부
 
+    @Setter
     @Column(name = "is_community_alarm_allowed")
     private boolean isCoummunityAlarmAllowed = false; // 커뮤니티 푸시 알람 여부
 

--- a/src/main/java/com/ripple/BE/user/service/UserProgressService.java
+++ b/src/main/java/com/ripple/BE/user/service/UserProgressService.java
@@ -1,11 +1,14 @@
 package com.ripple.BE.user.service;
 
+import com.ripple.BE.learning.domain.learningset.UserLearningSet;
 import com.ripple.BE.learning.repository.concept.ConceptRepository;
+import com.ripple.BE.learning.repository.learningSet.UserLearningSetRepository;
 import com.ripple.BE.learning.repository.quiz.QuizRepository;
 import com.ripple.BE.user.domain.User;
 import com.ripple.BE.user.domain.type.Level;
 import com.ripple.BE.user.dto.ProgressDTO;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +23,7 @@ public class UserProgressService {
 
     private final UserService userService;
 
+    private final UserLearningSetRepository userLearningSetRepository;
     private final ConceptRepository conceptRepository;
     private final QuizRepository quizRepository;
 
@@ -46,5 +50,21 @@ public class UserProgressService {
                                         level -> level,
                                         level ->
                                                 (double) user.getCompletedCountByLevel(level) / totalSets.get(level))));
+    }
+
+    @Transactional
+    public void updateLevel(final User user) {
+        List<UserLearningSet> userLearningSets =
+                userLearningSetRepository.findByUserIdAndLevel(user.getId(), user.getCurrentLevel());
+
+        if (!userLearningSets.isEmpty()) {
+            if (userLearningSets.stream().allMatch(UserLearningSet::isLearningSetCompleted)) {
+                if (user.getCurrentLevel() == Level.BEGINNER) {
+                    user.updateLevel(Level.INTERMEDIATE);
+                } else if (user.getCurrentLevel() == Level.INTERMEDIATE) {
+                    user.updateLevel(Level.ADVANCED);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/ripple/BE/user/service/UserService.java
+++ b/src/main/java/com/ripple/BE/user/service/UserService.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
@@ -97,7 +98,12 @@ public class UserService {
     @Transactional
     public void updateCompletedCountByLevel(User user, Level level) {
         user.increaseCompletedCountByLevel(level);
+    }
 
-        /** TODO: 레벨 업 조건 확인 후 레벨 업 처리 만약 상위 조건의 학습 세트를 완료한 경우 하위 레벨의 학습 세트가 완료되어야지 레벨 업이 가능하다. */
+    @Transactional
+    public void updateAlarm(final boolean alarm, final long userId) {
+
+        User user = findUserById(userId);
+        user.setCoummunityAlarmAllowed(alarm);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #46 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 푸시 알람 허용/차단 변경 기능 구현
- 개념 및 퀴즈 완료 시 레벨업 상태 확인 후 레벨 업 기능 구현
   - 해당 레벨의 학습 세트 전부 완료 시 레벨 없 
- 레벨별 학습 세트 조회 api -> Getmapping으로 수정




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?