### PR TITLE
[Feat] 스크랩 기능 추가 및 레벨별 진도율 조회 메소드 기능 수정

### DIFF
--- a/src/main/java/com/ripple/BE/learning/controller/ConceptController.java
+++ b/src/main/java/com/ripple/BE/learning/controller/ConceptController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/learning")
-@Tag(name = "Learning", description = "학습 API")
+@Tag(name = "Concept", description = "개념 학습 API")
 public class ConceptController {
 
     private final ConceptService conceptService;
@@ -52,8 +53,8 @@ public class ConceptController {
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
     }
 
-    @Operation(summary = "개념 학습 저장", description = "개념 학습을 저장합니다.")
-    @PostMapping("/learning/{conceptId}/scrap")
+    @Operation(summary = "개념 학습 스크랩", description = "개념 학습을 스크랩 처리합니다.")
+    @PostMapping("/concept/{conceptId}/scrap")
     public ResponseEntity<ApiResponse<?>> scrapConcept(
             final @AuthenticationPrincipal CustomUserDetails currentUser,
             final @PathVariable("conceptId") long conceptId) {
@@ -62,8 +63,19 @@ public class ConceptController {
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
     }
 
+    @Operation(summary = "개념 학습 스크랩 취소", description = "개념 학습 스크랩을 취소합니다.")
+    @DeleteMapping("/concept/{conceptId}/scrap")
+    public ResponseEntity<ApiResponse<Object>> unscrapConcept(
+            final @AuthenticationPrincipal CustomUserDetails currentUser,
+            final @PathVariable("conceptId") long id) {
+
+        conceptService.removeScrapFromConcept(id, currentUser.getId());
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(ApiResponse.EMPTY_RESPONSE));
+    }
+
     @Operation(summary = "개별 개념 학습 조회", description = "개별 개념 학습을 조회합니다.")
-    @GetMapping("/learning/{conceptId}")
+    @GetMapping("/concept/{conceptId}")
     public ResponseEntity<ApiResponse<Object>> getConcept(
             final @PathVariable("conceptId") long conceptId) {
 

--- a/src/main/java/com/ripple/BE/learning/controller/LearningController.java
+++ b/src/main/java/com/ripple/BE/learning/controller/LearningController.java
@@ -25,14 +25,16 @@ public class LearningController {
     private final LearningSetService learningSetService;
     private final LearningAdminService learningAdminService;
 
-    @Operation(summary = "학습 세트 생성", description = "엑셀 파일로부터 학습 세트를 생성합니다.")
+    @Operation(summary = "학습 세트 생성 (관리자 전용)", description = "엑셀 파일로부터 학습 세트를 생성합니다. (관리자 전용)")
     @PostMapping("/excel")
     public ResponseEntity<ApiResponse<?>> saveLearningSetsByExcel() {
         learningAdminService.createLearningSetByExcel();
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
     }
 
-    @Operation(summary = "레벨별 학습 세트 조회", description = "레벨별 전체 학습 세트를 조회합니다.")
+    @Operation(
+            summary = "레벨별 학습 세트 조회",
+            description = "레벨별 전체 학습 세트를 조회합니다. 사용자의 현재 레벨에 해당하는 학습 세트 목록을 반환합니다.")
     @PostMapping
     public ResponseEntity<ApiResponse<Object>> getLearningSets(
             final @AuthenticationPrincipal CustomUserDetails currentUser) {

--- a/src/main/java/com/ripple/BE/learning/controller/QuizController.java
+++ b/src/main/java/com/ripple/BE/learning/controller/QuizController.java
@@ -19,6 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,7 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/learning")
-@Tag(name = "Learning", description = "학습 API")
+@Tag(name = "Quiz", description = "퀴즈 API")
 public class QuizController {
 
     private final QuizService quizService;
@@ -74,8 +75,8 @@ public class QuizController {
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(ApiResponse.EMPTY_RESPONSE));
     }
 
-    @Operation(summary = "퀴즈 저장", description = "퀴즈를 저장합니다.")
-    @PostMapping("/learning/quiz/{quizId}/scrap")
+    @Operation(summary = "퀴즈 스크랩", description = "퀴즈를 스크랩 처리합니다.")
+    @PostMapping("/quiz/{quizId}/scrap")
     public ResponseEntity<ApiResponse<?>> scrapQuiz(
             final @AuthenticationPrincipal CustomUserDetails currentUser,
             final @PathVariable("quizId") long quizId) {
@@ -84,8 +85,19 @@ public class QuizController {
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
     }
 
+    @Operation(summary = "퀴즈 스크랩 취소", description = "퀴즈 스크랩을 취소합니다.")
+    @DeleteMapping("/quiz/{quizId}/scrap")
+    public ResponseEntity<ApiResponse<Object>> unscrapQuiz(
+            final @AuthenticationPrincipal CustomUserDetails currentUser,
+            final @PathVariable("quizId") long id) {
+
+        quizService.removeScrapFromQuiz(id, currentUser.getId());
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(ApiResponse.EMPTY_RESPONSE));
+    }
+
     @Operation(summary = "개별 퀴즈 조회", description = "개별 퀴즈를 조회합니다.")
-    @GetMapping("/learning/quiz/{quizId}")
+    @GetMapping("/quiz/{quizId}")
     public ResponseEntity<ApiResponse<Object>> getSingleQuiz(
             final @PathVariable("quizId") long quizId) {
 

--- a/src/main/java/com/ripple/BE/learning/exception/errorcode/LearningErrorCode.java
+++ b/src/main/java/com/ripple/BE/learning/exception/errorcode/LearningErrorCode.java
@@ -14,6 +14,7 @@ public enum LearningErrorCode implements ErrorCode {
 
     CONCEPT_NOT_FOUND(HttpStatus.NOT_FOUND, "Concept not found"),
     CONCEPT_ALREADY_SCRAP(HttpStatus.BAD_REQUEST, "Concept already scrap"),
+    CONCEPT_SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "Concept scrap not found"),
     QUIZ_PROGRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "Quiz progress not found"),
     QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "Quiz not found");
 

--- a/src/main/java/com/ripple/BE/learning/exception/errorcode/QuizErrorCode.java
+++ b/src/main/java/com/ripple/BE/learning/exception/errorcode/QuizErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum QuizErrorCode implements ErrorCode {
     QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "Quiz not found"),
-    QUIZ_ALREADY_SCRAP(HttpStatus.BAD_REQUEST, "Quiz already scrap");
+    QUIZ_ALREADY_SCRAP(HttpStatus.BAD_REQUEST, "Quiz already scrap"),
+    QUIZ_SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "Quiz scrap not found");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/ripple/BE/learning/repository/conceptScrap/ConceptScrapRepository.java
+++ b/src/main/java/com/ripple/BE/learning/repository/conceptScrap/ConceptScrapRepository.java
@@ -1,6 +1,7 @@
 package com.ripple.BE.learning.repository.conceptScrap;
 
 import com.ripple.BE.learning.domain.concept.ConceptScrap;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface ConceptScrapRepository
         extends JpaRepository<ConceptScrap, Long>, ConceptScrapRepositoryCustom {
     Boolean existsByConcept_ConceptIdAndUserId(Long conceptId, Long userId);
+
+    Optional<ConceptScrap> findByConcept_ConceptIdAndUserId(Long conceptId, Long userId);
 }

--- a/src/main/java/com/ripple/BE/learning/repository/quizScrap/QuizScrapRepository.java
+++ b/src/main/java/com/ripple/BE/learning/repository/quizScrap/QuizScrapRepository.java
@@ -1,6 +1,7 @@
 package com.ripple.BE.learning.repository.quizScrap;
 
 import com.ripple.BE.learning.domain.quiz.QuizScrap;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface QuizScrapRepository
         extends JpaRepository<QuizScrap, Long>, QuizScrapRepositoryCustom {
     Boolean existsByQuizIdAndUserId(Long quizId, Long userId);
+
+    Optional<QuizScrap> findByQuizIdAndUserId(Long quizId, Long userId);
 }

--- a/src/main/java/com/ripple/BE/learning/service/concept/ConceptService.java
+++ b/src/main/java/com/ripple/BE/learning/service/concept/ConceptService.java
@@ -94,6 +94,16 @@ public class ConceptService {
         conceptScrapRepository.save(ConceptScrap.builder().user(user).concept(concept).build());
     }
 
+    @Transactional
+    public void removeScrapFromConcept(final long conceptId, final long userId) {
+        ConceptScrap conceptScrap =
+                conceptScrapRepository
+                        .findByConcept_ConceptIdAndUserId(conceptId, userId)
+                        .orElseThrow(() -> new LearningException(LearningErrorCode.CONCEPT_SCRAP_NOT_FOUND));
+
+        conceptScrapRepository.delete(conceptScrap);
+    }
+
     /**
      * 개별 개념 조회
      *

--- a/src/main/java/com/ripple/BE/learning/service/quiz/QuizService.java
+++ b/src/main/java/com/ripple/BE/learning/service/quiz/QuizService.java
@@ -180,6 +180,16 @@ public class QuizService {
         quizScrapRepository.save(QuizScrap.builder().user(user).quiz(quiz).build());
     }
 
+    @Transactional
+    public void removeScrapFromQuiz(final long quizId, final long userId) {
+        QuizScrap quizScrap =
+                quizScrapRepository
+                        .findByQuizIdAndUserId(quizId, userId)
+                        .orElseThrow(() -> new QuizException(QuizErrorCode.QUIZ_SCRAP_NOT_FOUND));
+
+        quizScrapRepository.delete(quizScrap);
+    }
+
     /**
      * 개별 퀴즈 조회
      *

--- a/src/main/java/com/ripple/BE/news/controller/NewsController.java
+++ b/src/main/java/com/ripple/BE/news/controller/NewsController.java
@@ -67,7 +67,7 @@ public class NewsController {
 
     @Operation(summary = "뉴스 스크랩 취소", description = "뉴스 스크랩을 취소합니다.")
     @DeleteMapping("/{id}/scrap")
-    public ResponseEntity<ApiResponse<Object>> unscrapPost(
+    public ResponseEntity<ApiResponse<Object>> unscrapNews(
             final @AuthenticationPrincipal CustomUserDetails currentUser,
             final @PathVariable("id") long id) {
 

--- a/src/main/java/com/ripple/BE/news/dto/NewsListDTO.java
+++ b/src/main/java/com/ripple/BE/news/dto/NewsListDTO.java
@@ -12,4 +12,8 @@ public record NewsListDTO(List<NewsDTO> newsDTOList, int totalPage, int currentP
                 newsPage.getTotalPages(),
                 newsPage.getNumber());
     }
+
+    public static NewsListDTO toNewsListDTO(List<News> newsList) {
+        return new NewsListDTO(newsList.stream().map(NewsDTO::toNewsDTO).toList(), 1, 0);
+    }
 }

--- a/src/main/java/com/ripple/BE/news/repository/newscrap/NewsScrapRepository.java
+++ b/src/main/java/com/ripple/BE/news/repository/newscrap/NewsScrapRepository.java
@@ -4,7 +4,8 @@ import com.ripple.BE.news.domain.NewsScrap;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface NewsScrapRepository extends JpaRepository<NewsScrap, Long> {
+public interface NewsScrapRepository
+        extends JpaRepository<NewsScrap, Long>, NewsScrapRepositoryCustom {
 
     Optional<NewsScrap> findByNewsIdAndUserId(long newsId, long userId);
 

--- a/src/main/java/com/ripple/BE/news/repository/newscrap/NewsScrapRepositoryCustom.java
+++ b/src/main/java/com/ripple/BE/news/repository/newscrap/NewsScrapRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.ripple.BE.news.repository.newscrap;
+
+import com.ripple.BE.news.domain.News;
+import java.util.List;
+
+public interface NewsScrapRepositoryCustom {
+
+    List<News> findNewsScrappedByUser(Long userId);
+}

--- a/src/main/java/com/ripple/BE/news/repository/newscrap/NewsScrapRepositoryCustomImpl.java
+++ b/src/main/java/com/ripple/BE/news/repository/newscrap/NewsScrapRepositoryCustomImpl.java
@@ -1,0 +1,26 @@
+package com.ripple.BE.news.repository.newscrap;
+
+import static com.ripple.BE.news.domain.QNews.*;
+import static com.ripple.BE.news.domain.QNewsScrap.*;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ripple.BE.news.domain.News;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class NewsScrapRepositoryCustomImpl implements NewsScrapRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<News> findNewsScrappedByUser(Long userId) {
+        return queryFactory
+                .select(news)
+                .from(newsScrap)
+                .join(newsScrap.news, news)
+                .where(newsScrap.user.id.eq(userId))
+                .orderBy(newsScrap.createdDate.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/ripple/BE/post/controller/PostController.java
+++ b/src/main/java/com/ripple/BE/post/controller/PostController.java
@@ -40,7 +40,11 @@ public class PostController {
 
     private final PostService postService;
 
-    @Operation(summary = "게시물 작성", description = "게시물을 작성합니다. 게시물을 등록하기 전 이미지 등록을 완료해주세요")
+    @Operation(
+            summary = "게시물 작성",
+            description =
+                    "게시물을 작성합니다. 게시물을 등록하기 전 이미지 등록을 완료해주세요. 이미지 등록 후 반한 된 이미지 ID를 입력해주세요."
+                            + "게시물 타입은 FREE ,QUESTION, INFORMATION, BOOK_RECOMMENDATION 중 하나여야 합니다.")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Object>> createPost(
             final @AuthenticationPrincipal CustomUserDetails currentUser,

--- a/src/main/java/com/ripple/BE/post/repository/postscrap/PostScrapRepositoryCustomImpl.java
+++ b/src/main/java/com/ripple/BE/post/repository/postscrap/PostScrapRepositoryCustomImpl.java
@@ -20,6 +20,7 @@ public class PostScrapRepositoryCustomImpl implements PostScrapRepositoryCustom 
                 .from(postScrap)
                 .join(postScrap.post, post)
                 .where(postScrap.user.id.eq(userId))
+                .orderBy(postScrap.createdDate.desc())
                 .fetch();
     }
 }

--- a/src/main/java/com/ripple/BE/term/dto/TermListDTO.java
+++ b/src/main/java/com/ripple/BE/term/dto/TermListDTO.java
@@ -13,4 +13,8 @@ public record TermListDTO(List<TermDTO> termList, int totalPage, int currentPage
                 termPage.getTotalPages(),
                 termPage.getNumber());
     }
+
+    public static TermListDTO toTermListDTO(List<Term> termList) {
+        return new TermListDTO(termList.stream().map(TermDTO::toTermDTO).toList(), 1, 0);
+    }
 }

--- a/src/main/java/com/ripple/BE/term/repository/TermScrapRepository.java
+++ b/src/main/java/com/ripple/BE/term/repository/TermScrapRepository.java
@@ -4,7 +4,8 @@ import com.ripple.BE.term.domain.TermScrap;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TermScrapRepository extends JpaRepository<TermScrap, Long> {
+public interface TermScrapRepository
+        extends JpaRepository<TermScrap, Long>, TermScrapRepositoryCustom {
 
     Optional<TermScrap> findByTermIdAndUserId(long termId, long userId);
 

--- a/src/main/java/com/ripple/BE/term/repository/TermScrapRepositoryCustom.java
+++ b/src/main/java/com/ripple/BE/term/repository/TermScrapRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.ripple.BE.term.repository;
+
+import com.ripple.BE.term.domain.Term;
+import java.util.List;
+
+public interface TermScrapRepositoryCustom {
+
+    List<Term> findTermsScrappedByUserAndInitial(Long userId, String initial);
+
+    List<Term> findTermsScrappedByUserAndKeyword(Long userId, String keyword);
+}

--- a/src/main/java/com/ripple/BE/term/repository/TermScrapRepositoryCustomImpl.java
+++ b/src/main/java/com/ripple/BE/term/repository/TermScrapRepositoryCustomImpl.java
@@ -1,0 +1,57 @@
+package com.ripple.BE.term.repository;
+
+import static com.ripple.BE.term.domain.QTerm.*;
+import static com.ripple.BE.term.domain.QTermScrap.*;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ripple.BE.term.domain.Term;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TermScrapRepositoryCustomImpl implements TermScrapRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Term> findTermsScrappedByUserAndInitial(Long userId, String initial) {
+        if (initial == null || initial.trim().isEmpty()) {
+            return queryFactory
+                    .select(term)
+                    .from(termScrap)
+                    .join(termScrap.term, term)
+                    .where(termScrap.user.id.eq(userId))
+                    .orderBy(termScrap.createdDate.desc())
+                    .fetch();
+        }
+
+        return queryFactory
+                .select(term)
+                .from(termScrap)
+                .join(termScrap.term, term)
+                .where(termScrap.user.id.eq(userId).and(term.initial.startsWith(initial)))
+                .orderBy(termScrap.createdDate.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<Term> findTermsScrappedByUserAndKeyword(Long userId, String keyword) {
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return queryFactory
+                    .select(term)
+                    .from(termScrap)
+                    .join(termScrap.term, term)
+                    .where(termScrap.user.id.eq(userId))
+                    .orderBy(termScrap.createdDate.desc())
+                    .fetch();
+        }
+
+        return queryFactory
+                .select(term)
+                .from(termScrap)
+                .join(termScrap.term, term)
+                .where(termScrap.user.id.eq(userId).and(term.title.containsIgnoreCase(keyword)))
+                .orderBy(termScrap.createdDate.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/ripple/BE/user/controller/UserController.java
+++ b/src/main/java/com/ripple/BE/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.ripple.BE.user.controller;
 
+import static com.ripple.BE.global.exception.errorcode.GlobalErrorCode.*;
+
 import com.ripple.BE.global.dto.response.ApiResponse;
 import com.ripple.BE.learning.dto.ConceptListDTO;
 import com.ripple.BE.learning.dto.FailQuizListDTO;
@@ -7,10 +9,15 @@ import com.ripple.BE.learning.dto.QuizListDTO;
 import com.ripple.BE.learning.dto.response.FailQuizListResponse;
 import com.ripple.BE.learning.dto.response.ScrapConceptListResponse;
 import com.ripple.BE.learning.dto.response.ScrapQuizListResponse;
+import com.ripple.BE.news.dto.NewsListDTO;
+import com.ripple.BE.news.dto.response.NewsListResponse;
 import com.ripple.BE.post.dto.LikeCommentListDTO;
 import com.ripple.BE.post.dto.PostListDTO;
 import com.ripple.BE.post.dto.response.LikeCommentListResponse;
 import com.ripple.BE.post.dto.response.PostListResponse;
+import com.ripple.BE.term.dto.TermListDTO;
+import com.ripple.BE.term.dto.response.TermListResponse;
+import com.ripple.BE.term.exception.TermException;
 import com.ripple.BE.user.domain.CustomUserDetails;
 import com.ripple.BE.user.domain.type.Level;
 import com.ripple.BE.user.dto.ProgressDTO;
@@ -158,5 +165,50 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(
                         ApiResponse.from(ScrapConceptListResponse.toScrapConceptListResponse(conceptListDTO)));
+    }
+
+    @Operation(summary = "내가 스크랩한 뉴스 조회", description = "로그인한 유저가 스크랩한 뉴스를 조회합니다.")
+    @GetMapping("/scrap-news")
+    public ResponseEntity<ApiResponse<Object>> getMyScrapNews(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        NewsListDTO newsListDTO = myPageService.getMyScrapNews(customUserDetails.getId());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.from(NewsListResponse.toNewsListResponse(newsListDTO)));
+    }
+
+    @Operation(
+            summary = "내가 스크랩한 용어 조회",
+            description = "로그인한 유저가 스크랩한 용어를 조회합니다. 자음 별로 조회할 수 있으며, 아무것도 입력하지 않으면 모든 용어를 조회합니다.")
+    @GetMapping("/scrap-terms")
+    public ResponseEntity<ApiResponse<Object>> getMyScrapTermsByInitial(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam(value = "initial", required = false) final String initial) {
+
+        if (initial != null && initial.length() != 1) {
+            throw new TermException(INVALID_PARAMETER);
+        }
+
+        TermListDTO termListDTO =
+                myPageService.getMyScrapTermsByInitial(customUserDetails.getId(), initial);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.from(TermListResponse.toTermListResponse(termListDTO)));
+    }
+
+    @Operation(
+            summary = "내가 스크랩한 용어 조회",
+            description = "로그인한 유저가 스크랩한 용어를 조회합니다. 키워드 별로 조회할 수 있으며, 아무것도 입력하지 않으면 모든 용어를 조회합니다.")
+    @GetMapping("/scrap-terms/search")
+    public ResponseEntity<ApiResponse<Object>> getMyScrapTermsByKeyword(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam(value = "keyword", required = false) final String keyword) {
+
+        TermListDTO termListDTO =
+                myPageService.getMyScrapTermsByKeyword(customUserDetails.getId(), keyword);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.from(TermListResponse.toTermListResponse(termListDTO)));
     }
 }

--- a/src/main/java/com/ripple/BE/user/dto/ProgressResponse.java
+++ b/src/main/java/com/ripple/BE/user/dto/ProgressResponse.java
@@ -3,11 +3,18 @@ package com.ripple.BE.user.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.ripple.BE.user.domain.type.Level;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record ProgressResponse(Map<Level, Double> progress) {
+public record ProgressResponse(Map<Level, Integer> progress) {
 
     public static ProgressResponse toProgressResponse(final ProgressDTO levelDTO) {
-        return new ProgressResponse(levelDTO.progress());
+
+        Map<Level, Integer> progressMap =
+                levelDTO.progress().entrySet().stream()
+                        .collect(
+                                Collectors.toMap(Map.Entry::getKey, entry -> (int) Math.round(entry.getValue())));
+
+        return new ProgressResponse(progressMap);
     }
 }

--- a/src/main/java/com/ripple/BE/user/service/MyPageService.java
+++ b/src/main/java/com/ripple/BE/user/service/MyPageService.java
@@ -8,6 +8,9 @@ import com.ripple.BE.learning.dto.QuizListDTO;
 import com.ripple.BE.learning.repository.conceptScrap.ConceptScrapRepository;
 import com.ripple.BE.learning.repository.quiz.QuizRepository;
 import com.ripple.BE.learning.repository.quizScrap.QuizScrapRepository;
+import com.ripple.BE.news.domain.News;
+import com.ripple.BE.news.dto.NewsListDTO;
+import com.ripple.BE.news.repository.newscrap.NewsScrapRepository;
 import com.ripple.BE.post.domain.Comment;
 import com.ripple.BE.post.domain.Post;
 import com.ripple.BE.post.dto.LikeCommentListDTO;
@@ -17,6 +20,9 @@ import com.ripple.BE.post.repository.commentlike.CommentLikeRepository;
 import com.ripple.BE.post.repository.post.PostRepository;
 import com.ripple.BE.post.repository.postlike.PostLikeRepository;
 import com.ripple.BE.post.repository.postscrap.PostScrapRepository;
+import com.ripple.BE.term.domain.Term;
+import com.ripple.BE.term.dto.TermListDTO;
+import com.ripple.BE.term.repository.TermScrapRepository;
 import com.ripple.BE.user.domain.type.Level;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -38,8 +44,9 @@ public class MyPageService {
     private final QuizRepository quizRepository;
     private final QuizScrapRepository quizScrapRepository;
     private final ConceptScrapRepository conceptScrapRepository;
+    private final TermScrapRepository termScrapRepository;
+    private final NewsScrapRepository newsScrapRepository;
 
-    @Transactional(readOnly = true)
     public PostListDTO getMyPosts(final long userId) {
 
         List<Post> posts = postRepository.findUserNormalPosts(userId);
@@ -47,7 +54,6 @@ public class MyPageService {
         return PostListDTO.toPostListDTO(posts);
     }
 
-    @Transactional(readOnly = true)
     public PostListDTO getMyLikePosts(final long userId) {
 
         List<Post> posts = postLikeRepository.findPostsLikedByUser(userId);
@@ -55,7 +61,6 @@ public class MyPageService {
         return PostListDTO.toPostListDTO(posts);
     }
 
-    @Transactional(readOnly = true)
     public PostListDTO getMyCommentPosts(final long userId) {
 
         List<Post> posts = commentRepository.findPostsCommentedByUser(userId);
@@ -63,7 +68,6 @@ public class MyPageService {
         return PostListDTO.toPostListDTO(posts);
     }
 
-    @Transactional(readOnly = true)
     public PostListDTO getMyScrapPosts(final long userId) {
 
         List<Post> posts = postScrapRepository.findPostsScrappedByUser(userId);
@@ -71,7 +75,6 @@ public class MyPageService {
         return PostListDTO.toPostListDTO(posts);
     }
 
-    @Transactional(readOnly = true)
     public FailQuizListDTO getMyFailQuizzes(final long userId, Level level) {
 
         List<Quiz> failedQuizzesByUserAndLevel =
@@ -80,7 +83,6 @@ public class MyPageService {
         return FailQuizListDTO.toFailQuizListDTO(failedQuizzesByUserAndLevel);
     }
 
-    @Transactional(readOnly = true)
     public LikeCommentListDTO getMyLikeComments(final long userId) {
 
         List<Comment> commentsLikedByUser = commentLikeRepository.findCommentsLikedByUser(userId);
@@ -101,5 +103,24 @@ public class MyPageService {
                 conceptScrapRepository.findConceptsScrappedByUserAndLevel(userId, level);
 
         return ConceptListDTO.toScrapConceptListDTO(concepts);
+    }
+
+    public TermListDTO getMyScrapTermsByInitial(final long userId, final String initial) {
+
+        List<Term> terms = termScrapRepository.findTermsScrappedByUserAndInitial(userId, initial);
+
+        return TermListDTO.toTermListDTO(terms);
+    }
+
+    public TermListDTO getMyScrapTermsByKeyword(final long userId, final String keyword) {
+
+        List<Term> terms = termScrapRepository.findTermsScrappedByUserAndKeyword(userId, keyword);
+
+        return TermListDTO.toTermListDTO(terms);
+    }
+
+    public NewsListDTO getMyScrapNews(final long userId) {
+        List<News> news = newsScrapRepository.findNewsScrappedByUser(userId);
+        return NewsListDTO.toNewsListDTO(news);
     }
 }

--- a/src/main/java/com/ripple/BE/user/service/UserProgressService.java
+++ b/src/main/java/com/ripple/BE/user/service/UserProgressService.java
@@ -7,44 +7,94 @@ import com.ripple.BE.user.domain.type.Level;
 import com.ripple.BE.user.dto.ProgressDTO;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 @Slf4j
+@Transactional(readOnly = true)
 public class UserProgressService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String PROGRESS_KEY_PREFIX = "progress:";
+    private static final String TOTAL_SETS_KEY = "totalSets";
+
+    private static final int PROGRESS_CACHE_EXPIRE_MINUTES = 10;
+    private static final int TOTAL_SETS_CACHE_EXPIRE_DAYS = 1;
 
     private final UserService userService;
 
     private final ConceptRepository conceptRepository;
     private final QuizRepository quizRepository;
 
-    @Transactional(readOnly = true)
+    /**
+     * 레벨별 총 학습 세트 수를 조회한다. 개념 + 퀴즈 이 데이터는 캐시에 저장되며, 1일간 유효하다.
+     *
+     * @return 레벨별 총 학습 세트 수
+     */
+    public Map<String, Integer> getTotalLearningSetsCount() {
+        Map<String, Integer> totalSets =
+                (Map<String, Integer>) redisTemplate.opsForValue().get(TOTAL_SETS_KEY);
+
+        if (totalSets == null) {
+            totalSets =
+                    Arrays.stream(Level.values())
+                            .collect(
+                                    Collectors.toMap(
+                                            Enum::name,
+                                            level ->
+                                                    conceptRepository.countByLevel(level)
+                                                            + quizRepository.countByLevel(level)));
+
+            redisTemplate
+                    .opsForValue()
+                    .set(TOTAL_SETS_KEY, totalSets, TOTAL_SETS_CACHE_EXPIRE_DAYS, TimeUnit.DAYS);
+        }
+
+        return totalSets;
+    }
+
+    /**
+     * 유저의 레벨별 학습 완료율을 조회한다. 이 데이터는 캐시에 저장되며, 10분간 유효하다.
+     *
+     * @param userId 유저 ID
+     * @return 레벨별 학습 완료율
+     */
     public ProgressDTO getLearningSetCompletionRate(final long userId) {
-
         User user = userService.findUserById(userId);
+        String cacheKey = PROGRESS_KEY_PREFIX + userId;
 
-        // 레벨별 총 개념과 퀴즈 개수 계산
-        Map<Level, Integer> totalSets =
-                Arrays.stream(Level.values())
-                        .collect(
-                                Collectors.toMap(
-                                        level -> level,
-                                        level ->
-                                                conceptRepository.countByLevel(level)
-                                                        + quizRepository.countByLevel(level)));
+        Map<String, Integer> totalSets = getTotalLearningSetsCount();
+        ProgressDTO cachedProgress = (ProgressDTO) redisTemplate.opsForValue().get(cacheKey);
 
-        // 레벨별 완료율 계산
-        return ProgressDTO.toProgressDTO(
-                Arrays.stream(Level.values())
-                        .collect(
-                                Collectors.toMap(
-                                        level -> level,
-                                        level ->
-                                                (double) user.getCompletedCountByLevel(level) / totalSets.get(level))));
+        // 캐시된 데이터가 있으면 바로 반환
+        if (cachedProgress != null) {
+            return cachedProgress;
+        }
+
+        // 레벨별 완료율 계산, 퍼센트 단위로 변환
+        ProgressDTO progressDTO =
+                ProgressDTO.toProgressDTO(
+                        Arrays.stream(Level.values())
+                                .collect(
+                                        Collectors.toMap(
+                                                level -> level,
+                                                level ->
+                                                        (double) user.getCompletedCountByLevel(level)
+                                                                / totalSets.get(level.name())
+                                                                * 100)));
+
+        // 캐싱 (10분간 저장)
+        redisTemplate
+                .opsForValue()
+                .set(cacheKey, progressDTO, PROGRESS_CACHE_EXPIRE_MINUTES, TimeUnit.MINUTES);
+
+        return progressDTO;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #49 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### api 구현
- 개념 학습 스크랩 취소 api 구현
- 퀴즈 스크랩 취소 api 구현
- 내가 스크랩한 뉴스, 용어 목록 조회 api 구현

### api명 수정
- learning/learning으로 중복되던 api 명 수정

### 레벨별 진도율 조회 메소드 수정
- 캐시를 사용해서 DB 접근 줄이기




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?