### PR TITLE
Feat : 퀘스트 목표 변경 기능을 구현한다 #25

### DIFF
--- a/src/main/java/com/ripple/BE/user/controller/AttendanceController.java
+++ b/src/main/java/com/ripple/BE/user/controller/AttendanceController.java
@@ -35,7 +35,7 @@ public class AttendanceController {
 
     @Operation(
             summary = "오늘의 퀘스트 완료 여부 조회",
-            description = "오늘의 퀘스트 완료 여부를 조회합니다. 퍼센트로 반환됩니다. (0~100)")
+            description = "오늘의 퀘스트 완료 여부를 조회합니다. 퍼센트로 반환됩니다 (0~100). 매일 0시 1분 0초에 자동으로 초기화됩니다.")
     @GetMapping("/today-quest")
     public ResponseEntity<ApiResponse<?>> todayQuest(
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
@@ -45,7 +45,9 @@ public class AttendanceController {
                 .body(ApiResponse.from(QuestResponse.toQuestResponse(todayQuest)));
     }
 
-    @Operation(summary = "요일별 출석 현황 조회", description = "요일별 출석 현황을 조회합니다. 매주 자동으로 초기화됩니다.")
+    @Operation(
+            summary = "요일별 출석 현황 조회",
+            description = "요일별 출석 현황을 조회합니다. 매주 월요일 0시 0분 0초에 자동으로 초기화됩니다.")
     @GetMapping("/weekly-attendance")
     public ResponseEntity<ApiResponse<?>> weeklyAttendance(
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {

--- a/src/main/java/com/ripple/BE/user/controller/UserController.java
+++ b/src/main/java/com/ripple/BE/user/controller/UserController.java
@@ -21,9 +21,12 @@ import com.ripple.BE.term.exception.TermException;
 import com.ripple.BE.user.domain.CustomUserDetails;
 import com.ripple.BE.user.domain.type.Level;
 import com.ripple.BE.user.dto.ProgressDTO;
+import com.ripple.BE.user.dto.UserGoalDTO;
 import com.ripple.BE.user.dto.UserInfoDTO;
 import com.ripple.BE.user.dto.request.UpdateUserProfileRequest;
+import com.ripple.BE.user.dto.request.UserGoalRequest;
 import com.ripple.BE.user.dto.response.ProgressResponse;
+import com.ripple.BE.user.dto.response.UserGoalResponse;
 import com.ripple.BE.user.dto.response.UserInfoResponse;
 import com.ripple.BE.user.service.MyPageService;
 import com.ripple.BE.user.service.UserProgressService;
@@ -240,5 +243,26 @@ public class UserController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.from(UserInfoResponse.toUserInfoResponse(userInfo)));
+    }
+
+    @Operation(summary = "사용자 퀘스트 목표 조회", description = "로그인한 유저의 퀘스트 목표를 조회합니다.")
+    @GetMapping("/goal")
+    public ResponseEntity<ApiResponse<Object>> getUserGoal(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        UserGoalDTO userGoal = userService.getUserGoal(customUserDetails.getId());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.from(UserGoalResponse.toUserGoalResponse(userGoal)));
+    }
+
+    @Operation(summary = "사용자 퀘스트 목표 수정", description = "로그인한 유저의 퀘스트 목표를 수정합니다. 목표는 1 이상이어야 합니다.")
+    @PostMapping("/goal")
+    public ResponseEntity<ApiResponse<?>> updateUserGoal(
+            @Valid @RequestBody UserGoalRequest userGoalRequest,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        userService.updateUserGoal(userGoalRequest, customUserDetails.getId());
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
     }
 }

--- a/src/main/java/com/ripple/BE/user/domain/UserGoal.java
+++ b/src/main/java/com/ripple/BE/user/domain/UserGoal.java
@@ -1,6 +1,7 @@
 package com.ripple.BE.user.domain;
 
 import com.ripple.BE.global.entity.BaseEntity;
+import com.ripple.BE.user.dto.UserGoalDTO;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -33,6 +34,14 @@ public class UserGoal extends BaseEntity {
     private User user;
 
     private int quizGoal;
+
     private int conceptGoal;
+
     private int articleGoal;
+
+    public void updateQuizGoal(UserGoalDTO userGoalDTO) {
+        this.quizGoal = userGoalDTO.quizGoal();
+        this.conceptGoal = userGoalDTO.conceptGoal();
+        this.articleGoal = userGoalDTO.articleGoal();
+    }
 }

--- a/src/main/java/com/ripple/BE/user/domain/UserGoal.java
+++ b/src/main/java/com/ripple/BE/user/domain/UserGoal.java
@@ -9,54 +9,30 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Table(name = "quests")
+@Table(name = "user_goals")
 @Getter
 @Builder
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Quest extends BaseEntity {
+public class UserGoal extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "quest_id")
+    @Column(name = "user_goal_id")
     private Long id;
 
     @OneToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    private int quizCompletedCount;
-
-    private int conceptCompletedCount;
-
-    private int articleCompletedCount;
-
-    private LocalDate lastUpdatedDate; // 퀘스트 완료 날짜
-
-    public void resetQuests() {
-        this.quizCompletedCount = 0;
-        this.conceptCompletedCount = 0;
-        this.articleCompletedCount = 0;
-        this.lastUpdatedDate = LocalDate.now();
-    }
-
-    public void updateQuizCompletedCount() {
-        this.quizCompletedCount++;
-    }
-
-    public void updateConceptCompletedCount() {
-        this.conceptCompletedCount++;
-    }
-
-    public void updateArticleCompletedCount() {
-        this.articleCompletedCount++;
-    }
+    private int quizGoal;
+    private int conceptGoal;
+    private int articleGoal;
 }

--- a/src/main/java/com/ripple/BE/user/dto/QuestDTO.java
+++ b/src/main/java/com/ripple/BE/user/dto/QuestDTO.java
@@ -1,9 +1,9 @@
 package com.ripple.BE.user.dto;
 
-public record QuestDTO(Long conceptProgress, Long quizProgress, Long articleProgress) {
+public record QuestDTO(int conceptProgress, int quizProgress, int articleProgress) {
 
     public static QuestDTO toQuestDTO(
-            final Long conceptProgress, final Long quizProgress, final Long articleProgress) {
+            final int conceptProgress, final int quizProgress, final int articleProgress) {
         return new QuestDTO(conceptProgress, quizProgress, articleProgress);
     }
 }

--- a/src/main/java/com/ripple/BE/user/dto/UserGoalDTO.java
+++ b/src/main/java/com/ripple/BE/user/dto/UserGoalDTO.java
@@ -1,0 +1,11 @@
+package com.ripple.BE.user.dto;
+
+import com.ripple.BE.user.dto.request.UserGoalRequest;
+
+public record UserGoalDTO(int conceptGoal, int quizGoal, int articleGoal) {
+
+    public static UserGoalDTO toUserGoalDTO(UserGoalRequest userGoalRequest) {
+        return new UserGoalDTO(
+                userGoalRequest.conceptGoal(), userGoalRequest.quizGoal(), userGoalRequest.articleGoal());
+    }
+}

--- a/src/main/java/com/ripple/BE/user/dto/request/UserGoalRequest.java
+++ b/src/main/java/com/ripple/BE/user/dto/request/UserGoalRequest.java
@@ -1,0 +1,8 @@
+package com.ripple.BE.user.dto.request;
+
+import jakarta.validation.constraints.Min;
+
+public record UserGoalRequest(
+        @Min(value = 1, message = "1 이상의 값을 입력해주세요.") int conceptGoal,
+        @Min(value = 1, message = "1 이상의 값을 입력해주세요.") int quizGoal,
+        @Min(value = 1, message = "1 이상의 값을 입력해주세요.") int articleGoal) {}

--- a/src/main/java/com/ripple/BE/user/dto/response/QuestResponse.java
+++ b/src/main/java/com/ripple/BE/user/dto/response/QuestResponse.java
@@ -2,7 +2,7 @@ package com.ripple.BE.user.dto.response;
 
 import com.ripple.BE.user.dto.QuestDTO;
 
-public record QuestResponse(Long conceptProgress, Long quizProgress, Long articleProgress) {
+public record QuestResponse(int conceptProgress, int quizProgress, int articleProgress) {
 
     public static QuestResponse toQuestResponse(QuestDTO questDTO) {
         return new QuestResponse(

--- a/src/main/java/com/ripple/BE/user/dto/response/UserGoalResponse.java
+++ b/src/main/java/com/ripple/BE/user/dto/response/UserGoalResponse.java
@@ -1,0 +1,10 @@
+package com.ripple.BE.user.dto.response;
+
+import com.ripple.BE.user.dto.UserGoalDTO;
+
+public record UserGoalResponse(int conceptGoal, int quizGoal, int articleGoal) {
+    public static UserGoalResponse toUserGoalResponse(UserGoalDTO userGoalDTO) {
+        return new UserGoalResponse(
+                userGoalDTO.conceptGoal(), userGoalDTO.quizGoal(), userGoalDTO.articleGoal());
+    }
+}

--- a/src/main/java/com/ripple/BE/user/exception/errorcode/UserErrorCode.java
+++ b/src/main/java/com/ripple/BE/user/exception/errorcode/UserErrorCode.java
@@ -14,6 +14,7 @@ public enum UserErrorCode implements ErrorCode {
     INVALID_QUEST_TYPE(HttpStatus.BAD_REQUEST, "Invalid Quest Type"),
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "Already exist Email"),
     QUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "Quest not found"),
+    USER_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "User Goal not found"),
     ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Attendance not found");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/ripple/BE/user/repository/UserGoalRepository.java
+++ b/src/main/java/com/ripple/BE/user/repository/UserGoalRepository.java
@@ -1,0 +1,11 @@
+package com.ripple.BE.user.repository;
+
+import com.ripple.BE.user.domain.UserGoal;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserGoalRepository extends JpaRepository<UserGoal, Long> {
+    Optional<UserGoal> findByUserId(Long userId);
+}

--- a/src/main/java/com/ripple/BE/user/service/AttendanceScheduler.java
+++ b/src/main/java/com/ripple/BE/user/service/AttendanceScheduler.java
@@ -1,11 +1,5 @@
 package com.ripple.BE.user.service;
 
-import com.ripple.BE.user.domain.AttendanceLog;
-import com.ripple.BE.user.domain.Quest;
-import com.ripple.BE.user.repository.AttendanceLogRepository;
-import com.ripple.BE.user.repository.AttendanceRepository;
-import com.ripple.BE.user.repository.QuestRepository;
-import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -15,36 +9,23 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AttendanceScheduler {
 
-    private final AttendanceLogRepository attendanceLogRepository;
-    private final QuestRepository questRepository;
-    private final AttendanceRepository attendanceRepository;
+    private final AttendanceService attendanceService;
 
     @Scheduled(cron = "0 0 0 * * MON") // 매주 월요일 0시 0분 0초에 실행
-    public void resetWeeklyAttendance() {
-        attendanceLogRepository.deleteAll();
-    }
-
-    @Scheduled(cron = "0 0 0 * * ?") // 매일 0시 0분 0초에 실행
     @Transactional
-    public void resetAllQuests() {
-        questRepository.findAll().forEach(Quest::resetQuests);
+    public void resetWeeklyAttendanceLog() {
+        attendanceService.resetWeeklyAttendanceLog();
     }
 
-    @Scheduled(cron = "0 0 0 * * ?") // 매일 0시 0분 0초에 실행
+    @Scheduled(cron = "30 0 0 * * ?") //  매일 0시 0분 30초에 실행
     @Transactional
     public void recordAttendanceLog() {
-        LocalDate today = LocalDate.now();
+        attendanceService.recordAttendanceLog();
+    }
 
-        attendanceRepository
-                .findAll()
-                .forEach(
-                        attendance -> {
-                            attendanceLogRepository.save(
-                                    AttendanceLog.builder()
-                                            .attendance(attendance)
-                                            .date(today)
-                                            .isAttended(false)
-                                            .build());
-                        });
+    @Scheduled(cron = "0 1 0 * * ?") // 매일 0시 1분 0초에 실행
+    @Transactional
+    public void resetAllQuests() {
+        attendanceService.resetAllQuests();
     }
 }

--- a/src/main/java/com/ripple/BE/user/service/AttendanceService.java
+++ b/src/main/java/com/ripple/BE/user/service/AttendanceService.java
@@ -80,7 +80,7 @@ public class AttendanceService {
             default -> throw new UserException(INVALID_QUEST_TYPE);
         }
 
-        // 퀘스트 3개 완료 시 출석 완료 처리
+        // 퀘스트 완료 시 출석 처리
         if (quest.getArticleCompletedCount() >= userGoal.getArticleGoal()
                 && quest.getConceptCompletedCount() >= userGoal.getConceptGoal()
                 && quest.getQuizCompletedCount() >= userGoal.getQuizGoal()) {

--- a/src/main/java/com/ripple/BE/user/service/AttendanceService.java
+++ b/src/main/java/com/ripple/BE/user/service/AttendanceService.java
@@ -31,11 +31,16 @@ public class AttendanceService {
     private final AttendanceRepository attendanceRepository;
     private final AttendanceLogRepository attendanceLogRepository;
 
+    @Transactional
     public Long getCurrentStreak(Long id) {
         Attendance attendance =
                 attendanceRepository
                         .findByUserId(id)
                         .orElseThrow(() -> new UserException(ATTENDANCE_NOT_FOUND));
+
+        if (attendance.getLastAttendedDate().isBefore(LocalDate.now().minusDays(1))) {
+            attendance.updateCurrentStreak(1L);
+        }
 
         return attendance.getCurrentStreak();
     }

--- a/src/main/java/com/ripple/BE/user/service/AttendanceService.java
+++ b/src/main/java/com/ripple/BE/user/service/AttendanceService.java
@@ -6,12 +6,14 @@ import com.ripple.BE.user.domain.Attendance;
 import com.ripple.BE.user.domain.AttendanceLog;
 import com.ripple.BE.user.domain.Quest;
 import com.ripple.BE.user.domain.User;
+import com.ripple.BE.user.domain.UserGoal;
 import com.ripple.BE.user.dto.AttendanceDTO;
 import com.ripple.BE.user.dto.QuestDTO;
 import com.ripple.BE.user.exception.UserException;
 import com.ripple.BE.user.repository.AttendanceLogRepository;
 import com.ripple.BE.user.repository.AttendanceRepository;
 import com.ripple.BE.user.repository.QuestRepository;
+import com.ripple.BE.user.repository.UserGoalRepository;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,6 +32,7 @@ public class AttendanceService {
     private final QuestRepository questRepository;
     private final AttendanceRepository attendanceRepository;
     private final AttendanceLogRepository attendanceLogRepository;
+    private final UserGoalRepository userGoalRepository;
 
     @Transactional
     public Long getCurrentStreak(Long id) {
@@ -48,30 +51,38 @@ public class AttendanceService {
     public QuestDTO getTodayQuest(Long id) {
         Quest quest =
                 questRepository.findByUserId(id).orElseThrow(() -> new UserException(QUEST_NOT_FOUND));
+        UserGoal userGoal =
+                userGoalRepository
+                        .findByUserId(id)
+                        .orElseThrow(() -> new UserException(USER_GOAL_NOT_FOUND));
 
         return QuestDTO.toQuestDTO(
-                quest.isConceptCompleted() ? 100L : 0L,
-                quest.isQuizCompleted() ? 100L : 0L,
-                quest.getArticleCompletedCount() / 3 * 100);
+                Math.min(100, quest.getConceptCompletedCount() * 100 / userGoal.getConceptGoal()),
+                Math.min(100, quest.getQuizCompletedCount() * 100 / userGoal.getQuizGoal()),
+                Math.min(100, quest.getArticleCompletedCount() * 100 / userGoal.getArticleGoal()));
     }
 
     @Transactional
     public void completeQuest(Long userId, String questType) {
         Quest quest =
                 questRepository.findByUserId(userId).orElseThrow(() -> new UserException(QUEST_NOT_FOUND));
+        UserGoal userGoal =
+                userGoalRepository
+                        .findByUserId(userId)
+                        .orElseThrow(() -> new UserException(USER_GOAL_NOT_FOUND));
 
         // 퀘스트 타입에 따라 완료 처리
         switch (questType.toUpperCase()) {
-            case "QUIZ" -> quest.updateQuizCompleted();
-            case "CONCEPT" -> quest.updateConceptCompleted();
+            case "QUIZ" -> quest.updateQuizCompletedCount();
+            case "CONCEPT" -> quest.updateConceptCompletedCount();
             case "ARTICLE" -> quest.updateArticleCompletedCount();
             default -> throw new UserException(INVALID_QUEST_TYPE);
         }
 
         // 퀘스트 3개 완료 시 출석 완료 처리
-        if (quest.getArticleCompletedCount() >= 3
-                && quest.isConceptCompleted()
-                && quest.isQuizCompleted()) {
+        if (quest.getArticleCompletedCount() >= userGoal.getArticleGoal()
+                && quest.getConceptCompletedCount() >= userGoal.getConceptGoal()
+                && quest.getQuizCompletedCount() >= userGoal.getQuizGoal()) {
             completeAttendance(userId, LocalDate.now());
         }
     }
@@ -113,6 +124,8 @@ public class AttendanceService {
         questRepository.save(Quest.builder().user(user).lastUpdatedDate(today).build());
         attendanceLogRepository.save(
                 AttendanceLog.builder().date(today).isAttended(false).attendance(attendance).build());
+        userGoalRepository.save(
+                UserGoal.builder().user(user).quizGoal(1).articleGoal(3).conceptGoal(1).build());
     }
 
     @Transactional

--- a/src/main/java/com/ripple/BE/user/service/AttendanceService.java
+++ b/src/main/java/com/ripple/BE/user/service/AttendanceService.java
@@ -136,4 +136,29 @@ public class AttendanceService {
                 .sunday(weeklyAttendance.get(6))
                 .build();
     }
+
+    @Transactional
+    public void resetWeeklyAttendanceLog() {
+        attendanceLogRepository.deleteAll();
+    }
+
+    @Transactional
+    public void resetAllQuests() {
+        questRepository.findAll().forEach(Quest::resetQuests);
+    }
+
+    @Transactional
+    public void recordAttendanceLog() {
+        attendanceRepository
+                .findAll()
+                .forEach(
+                        attendance -> {
+                            attendanceLogRepository.save(
+                                    AttendanceLog.builder()
+                                            .attendance(attendance)
+                                            .date(LocalDate.now())
+                                            .isAttended(false)
+                                            .build());
+                        });
+    }
 }

--- a/src/main/java/com/ripple/BE/user/service/AttendanceService.java
+++ b/src/main/java/com/ripple/BE/user/service/AttendanceService.java
@@ -41,7 +41,8 @@ public class AttendanceService {
                         .findByUserId(id)
                         .orElseThrow(() -> new UserException(ATTENDANCE_NOT_FOUND));
 
-        if (attendance.getLastAttendedDate().isBefore(LocalDate.now().minusDays(1))) {
+        if (attendance.getLastAttendedDate() != null
+                && attendance.getLastAttendedDate().isBefore(LocalDate.now().minusDays(1))) {
             attendance.updateCurrentStreak(1L);
         }
 

--- a/src/main/java/com/ripple/BE/user/service/UserService.java
+++ b/src/main/java/com/ripple/BE/user/service/UserService.java
@@ -8,11 +8,15 @@ import com.ripple.BE.image.domain.Image;
 import com.ripple.BE.image.repository.ImageRepository;
 import com.ripple.BE.learning.domain.quiz.FailQuiz;
 import com.ripple.BE.user.domain.User;
+import com.ripple.BE.user.domain.UserGoal;
 import com.ripple.BE.user.domain.type.Level;
 import com.ripple.BE.user.domain.type.LoginType;
+import com.ripple.BE.user.dto.UserGoalDTO;
 import com.ripple.BE.user.dto.UserInfoDTO;
 import com.ripple.BE.user.dto.request.UpdateUserProfileRequest;
+import com.ripple.BE.user.dto.request.UserGoalRequest;
 import com.ripple.BE.user.exception.UserException;
+import com.ripple.BE.user.repository.UserGoalRepository;
 import com.ripple.BE.user.repository.UserRepository;
 import java.util.Date;
 import java.util.List;
@@ -33,6 +37,7 @@ public class UserService {
     private final ImageRepository imageRepository;
     private final AttendanceService attendanceService;
 
+    private final UserGoalRepository userGoalRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
@@ -150,5 +155,25 @@ public class UserService {
                 .level(user.getCurrentLevel())
                 .quizCorrectRate(quizCorrectRate)
                 .build();
+    }
+
+    public UserGoalDTO getUserGoal(final long userId) {
+        UserGoal userGoal =
+                userGoalRepository
+                        .findByUserId(userId)
+                        .orElseThrow(() -> new UserException(USER_GOAL_NOT_FOUND));
+
+        return new UserGoalDTO(
+                userGoal.getConceptGoal(), userGoal.getQuizGoal(), userGoal.getArticleGoal());
+    }
+
+    @Transactional
+    public void updateUserGoal(final UserGoalRequest userGoalRequest, final long userId) {
+        UserGoal userGoal =
+                userGoalRepository
+                        .findByUserId(userId)
+                        .orElseThrow(() -> new UserException(USER_GOAL_NOT_FOUND));
+
+        userGoal.updateQuizGoal(UserGoalDTO.toUserGoalDTO(userGoalRequest));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #25 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 퀘스트 초기화 컨트롤러 로직 수정
- 사용자 별 퀘스트 테이블을 따로 생성하여 목표 변경, 조회 할 수 있도록 변경




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?