### PR TITLE
Feat : 유저 프로필 수정 api 추가  (#25)

### DIFF
--- a/src/main/java/com/ripple/BE/user/controller/UserController.java
+++ b/src/main/java/com/ripple/BE/user/controller/UserController.java
@@ -60,7 +60,9 @@ public class UserController {
     @Operation(
             summary = "프로필 등록",
             description =
-                    "로그인 후 유저의 프로필을 등록합니다." + "프로필을 등록하기 전 이미지 등록을 완료해주세요. 이미지 등록 후 반한 된 이미지 ID를 입력해주세요.")
+                    "로그인 후 유저의 프로필을 등록합니다."
+                            + "닉네임, 업종, 직업, 생일은 필수입니다. 닉네임은 중복 불가능합니다. (2~10)"
+                            + "프로필을 등록하기 전 이미지 등록 후 반한 된 이미지 ID를 입력해주세요.")
     @PostMapping("/profile")
     public ResponseEntity<ApiResponse<?>> profile(
             @Valid @RequestBody UpdateUserProfileRequest request,

--- a/src/main/java/com/ripple/BE/user/controller/UserController.java
+++ b/src/main/java/com/ripple/BE/user/controller/UserController.java
@@ -23,6 +23,7 @@ import com.ripple.BE.user.domain.type.Level;
 import com.ripple.BE.user.dto.ProgressDTO;
 import com.ripple.BE.user.dto.UserGoalDTO;
 import com.ripple.BE.user.dto.UserInfoDTO;
+import com.ripple.BE.user.dto.request.PatchUserProfileRequest;
 import com.ripple.BE.user.dto.request.UpdateUserProfileRequest;
 import com.ripple.BE.user.dto.request.UserGoalRequest;
 import com.ripple.BE.user.dto.response.ProgressResponse;
@@ -39,6 +40,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -262,6 +264,17 @@ public class UserController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         userService.updateUserGoal(userGoalRequest, customUserDetails.getId());
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
+    }
+
+    @Operation(summary = "유저 프로필 수정", description = "로그인한 유저의 프로필을 수정합니다. 수정할 필드만 입력하면 됩니다. ")
+    @PatchMapping("/profile")
+    public ResponseEntity<ApiResponse<?>> patchUserProfile(
+            @Valid @RequestBody PatchUserProfileRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        userService.patchUserProfile(request, customUserDetails.getId());
 
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
     }

--- a/src/main/java/com/ripple/BE/user/domain/User.java
+++ b/src/main/java/com/ripple/BE/user/domain/User.java
@@ -222,4 +222,40 @@ public class User extends BaseEntity {
     public void updateLevel(Level level) {
         this.currentLevel = level;
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateBusinessType(String businessType) {
+        this.businessType = BusinessType.from(businessType);
+    }
+
+    public void updateJob(String job) {
+        this.job = Job.from(job);
+    }
+
+    public void updateBirthDate(Date birthDate) {
+        this.birthDate = birthDate;
+    }
+
+    public void updateGender(Gender gender) {
+        this.gender = gender;
+    }
+
+    public void updateProfileIntro(String profileIntro) {
+        this.profileIntro = profileIntro;
+    }
+
+    public void updateProfileImage(Image image) {
+        this.profileImage = image;
+    }
+
+    public void updateLearningAlarmAllowed(boolean isLearningAlarmAllowed) {
+        this.isLearningAlarmAllowed = isLearningAlarmAllowed;
+    }
+
+    public void updateCommunityAlarmAllowed(boolean isCommunityAlarmAllowed) {
+        this.isCoummunityAlarmAllowed = isCommunityAlarmAllowed;
+    }
 }

--- a/src/main/java/com/ripple/BE/user/domain/User.java
+++ b/src/main/java/com/ripple/BE/user/domain/User.java
@@ -67,7 +67,7 @@ public class User extends BaseEntity {
     private Role role;
 
     @Size(min = 2, max = 20)
-    @Column(name = "nickname", nullable = false, unique = true)
+    @Column(name = "nickname", unique = true)
     private String nickname;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/ripple/BE/user/domain/User.java
+++ b/src/main/java/com/ripple/BE/user/domain/User.java
@@ -55,7 +55,7 @@ public class User extends BaseEntity {
     private Long id;
 
     @Size(min = 5, max = 50)
-    @Column(name = "account_email", nullable = false)
+    @Column(name = "account_email", nullable = false, unique = true)
     private String accountEmail; // 카카오 로그인 시에는 카카오 서버에서 받아옴
 
     @Size(min = 8, max = 255)
@@ -67,7 +67,7 @@ public class User extends BaseEntity {
     private Role role;
 
     @Size(min = 2, max = 20)
-    @Column(name = "nickname")
+    @Column(name = "nickname", nullable = false, unique = true)
     private String nickname;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/ripple/BE/user/dto/request/PatchUserProfileRequest.java
+++ b/src/main/java/com/ripple/BE/user/dto/request/PatchUserProfileRequest.java
@@ -1,0 +1,15 @@
+package com.ripple.BE.user.dto.request;
+
+import com.ripple.BE.user.domain.type.Gender;
+import java.util.Date;
+
+public record PatchUserProfileRequest(
+        String nickname,
+        String businessType,
+        String job,
+        Date birthDate,
+        Gender gender,
+        String profileIntro,
+        Boolean isLearningAlarmAllowed,
+        Boolean isCommunityAlarmAllowed,
+        Long imageId) {}

--- a/src/main/java/com/ripple/BE/user/exception/errorcode/UserErrorCode.java
+++ b/src/main/java/com/ripple/BE/user/exception/errorcode/UserErrorCode.java
@@ -15,6 +15,8 @@ public enum UserErrorCode implements ErrorCode {
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "Already exist Email"),
     QUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "Quest not found"),
     USER_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "User Goal not found"),
+    DUPLICATED_NICKNAME(
+            HttpStatus.BAD_REQUEST, "Duplicated Nickname is already exist. Please use another nickname"),
     ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Attendance not found");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/ripple/BE/user/repository/UserRepository.java
+++ b/src/main/java/com/ripple/BE/user/repository/UserRepository.java
@@ -17,4 +17,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select u from User u")
     List<User> findAllWithLock();
+
+    Boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/ripple/BE/user/service/UserService.java
+++ b/src/main/java/com/ripple/BE/user/service/UserService.java
@@ -59,8 +59,10 @@ public class UserService {
 
     @Transactional
     public void updateProfile(UpdateUserProfileRequest request, Long userId) {
-        User user =
-                userRepository.findById(userId).orElseThrow(() -> new UserException(USER_NOT_FOUND));
+        User user = findUserById(userId);
+        if (userRepository.existsByNickname(request.nickname())) { // 닉네임 중복 확인
+            throw new UserException(DUPLICATED_NICKNAME);
+        }
 
         Image image = null;
         if (request.imageId() != null) {

--- a/src/main/java/com/ripple/BE/user/service/UserService.java
+++ b/src/main/java/com/ripple/BE/user/service/UserService.java
@@ -13,6 +13,7 @@ import com.ripple.BE.user.domain.type.Level;
 import com.ripple.BE.user.domain.type.LoginType;
 import com.ripple.BE.user.dto.UserGoalDTO;
 import com.ripple.BE.user.dto.UserInfoDTO;
+import com.ripple.BE.user.dto.request.PatchUserProfileRequest;
 import com.ripple.BE.user.dto.request.UpdateUserProfileRequest;
 import com.ripple.BE.user.dto.request.UserGoalRequest;
 import com.ripple.BE.user.exception.UserException;
@@ -177,5 +178,55 @@ public class UserService {
                         .orElseThrow(() -> new UserException(USER_GOAL_NOT_FOUND));
 
         userGoal.updateQuizGoal(UserGoalDTO.toUserGoalDTO(userGoalRequest));
+    }
+
+    @Transactional
+    public void patchUserProfile(
+            final PatchUserProfileRequest updateUserProfileRequest, final long userId) {
+        User user = findUserById(userId);
+
+        if (updateUserProfileRequest.nickname() != null) {
+            if (userRepository.existsByNickname(updateUserProfileRequest.nickname())) {
+                throw new UserException(DUPLICATED_NICKNAME);
+            }
+            user.updateNickname(updateUserProfileRequest.nickname());
+        }
+
+        if (updateUserProfileRequest.businessType() != null) {
+            user.updateBusinessType(updateUserProfileRequest.businessType());
+        }
+
+        if (updateUserProfileRequest.job() != null) {
+            user.updateJob(updateUserProfileRequest.job());
+        }
+
+        if (updateUserProfileRequest.birthDate() != null) {
+            user.updateBirthDate(updateUserProfileRequest.birthDate());
+        }
+
+        if (updateUserProfileRequest.gender() != null) {
+            user.updateGender(updateUserProfileRequest.gender());
+        }
+
+        if (updateUserProfileRequest.profileIntro() != null) {
+            user.updateProfileIntro(updateUserProfileRequest.profileIntro());
+        }
+
+        if (updateUserProfileRequest.isLearningAlarmAllowed() != null) {
+            user.updateLearningAlarmAllowed(updateUserProfileRequest.isLearningAlarmAllowed());
+        }
+
+        if (updateUserProfileRequest.isCommunityAlarmAllowed() != null) {
+            user.updateCommunityAlarmAllowed(updateUserProfileRequest.isCommunityAlarmAllowed());
+        }
+
+        if (updateUserProfileRequest.imageId() != null) {
+            Image image =
+                    imageRepository
+                            .findById(updateUserProfileRequest.imageId())
+                            .orElseThrow(() -> new UserException(IMAGE_NOT_FOUND));
+
+            user.updateProfileImage(image);
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #25 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- patch mapping으로 유저 프로필을 수정할 수 있는 api를 추가하였습니다.
- 닉네임 중복 검사를 추가했습니다
-




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?