### PR TITLE
[Feat] 퀘스트, 사용자 관련 오류 (#25)

### DIFF
--- a/src/main/java/com/ripple/BE/learning/service/LevelTestService.java
+++ b/src/main/java/com/ripple/BE/learning/service/LevelTestService.java
@@ -113,6 +113,7 @@ public class LevelTestService {
                 userRepository.findById(userId).orElseThrow(() -> new UserException(USER_NOT_FOUND));
         Level level = calculateLevel(score);
         user.updateLevel(level);
+        user.updateLevelTestCompleted(true);
         return level;
     }
 

--- a/src/main/java/com/ripple/BE/learning/service/concept/ConceptService.java
+++ b/src/main/java/com/ripple/BE/learning/service/concept/ConceptService.java
@@ -77,7 +77,9 @@ public class ConceptService {
             userProgressService.updateLevel(user);
         }
 
-        attendanceService.completeQuest(userId, "CONCEPT");
+        if (user.getCurrentLevel() == userLearningSet.getLevel()) {
+            attendanceService.completeQuest(userId, "CONCEPT");
+        }
     }
 
     /**

--- a/src/main/java/com/ripple/BE/learning/service/quiz/QuizService.java
+++ b/src/main/java/com/ripple/BE/learning/service/quiz/QuizService.java
@@ -148,7 +148,9 @@ public class QuizService {
 
         quizRedisService.clearRedisKeys(userId); // 퀴즈 진행 관련 데이터 삭제
 
-        attendanceService.completeQuest(userId, "QUIZ");
+        if (userLearningSet.getLevel() == user.getCurrentLevel()) {
+            attendanceService.completeQuest(userId, "QUIZ");
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ripple/BE/user/controller/UserController.java
+++ b/src/main/java/com/ripple/BE/user/controller/UserController.java
@@ -21,12 +21,14 @@ import com.ripple.BE.term.exception.TermException;
 import com.ripple.BE.user.domain.CustomUserDetails;
 import com.ripple.BE.user.domain.type.Level;
 import com.ripple.BE.user.dto.ProgressDTO;
+import com.ripple.BE.user.dto.UserCompletedDTO;
 import com.ripple.BE.user.dto.UserGoalDTO;
 import com.ripple.BE.user.dto.UserInfoDTO;
 import com.ripple.BE.user.dto.request.PatchUserProfileRequest;
 import com.ripple.BE.user.dto.request.UpdateUserProfileRequest;
 import com.ripple.BE.user.dto.request.UserGoalRequest;
 import com.ripple.BE.user.dto.response.ProgressResponse;
+import com.ripple.BE.user.dto.response.UserCompletedResponse;
 import com.ripple.BE.user.dto.response.UserGoalResponse;
 import com.ripple.BE.user.dto.response.UserInfoResponse;
 import com.ripple.BE.user.service.MyPageService;
@@ -279,5 +281,19 @@ public class UserController {
         userService.patchUserProfile(request, customUserDetails.getId());
 
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
+    }
+
+    @Operation(summary = "유저가 완료한 학습과 퀴즈 갯수 반환", description = "로그인한 유저가 완료한 학습과 퀴즈 갯수를 반환합니다.")
+    @GetMapping("/completed")
+    public ResponseEntity<ApiResponse<Object>> getCompletedConceptAndQuizCount(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        UserCompletedDTO completedConceptAndQuizCount =
+                myPageService.getCompletedConceptAndQuizCount(customUserDetails.getId());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(
+                        ApiResponse.from(
+                                UserCompletedResponse.toUserCompletedResponse(completedConceptAndQuizCount)));
     }
 }

--- a/src/main/java/com/ripple/BE/user/domain/User.java
+++ b/src/main/java/com/ripple/BE/user/domain/User.java
@@ -111,6 +111,9 @@ public class User extends BaseEntity {
     @Column(name = "is_profile_completed")
     private boolean isProfileCompleted = false; // 최초 1회 프로필 등록
 
+    @Column(name = "is_level_test_completed")
+    private boolean isLevelTestCompleted = false; // 레벨 테스트 완료 여부
+
     @OneToMany(mappedBy = "author", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Post> postList = new ArrayList<>(); // 작성한 게시글 목록
 
@@ -257,5 +260,9 @@ public class User extends BaseEntity {
 
     public void updateCommunityAlarmAllowed(boolean isCommunityAlarmAllowed) {
         this.isCoummunityAlarmAllowed = isCommunityAlarmAllowed;
+    }
+
+    public void updateLevelTestCompleted(boolean isLevelTestCompleted) {
+        this.isLevelTestCompleted = isLevelTestCompleted;
     }
 }

--- a/src/main/java/com/ripple/BE/user/dto/UserCompletedDTO.java
+++ b/src/main/java/com/ripple/BE/user/dto/UserCompletedDTO.java
@@ -1,0 +1,12 @@
+package com.ripple.BE.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UserCompletedDTO(
+        long userId,
+        long beginnerCompletedCount,
+        long intermediateCompletedCount,
+        long advancedCompletedCount,
+        long totalConceptCompletedCount,
+        long quizCount) {}

--- a/src/main/java/com/ripple/BE/user/dto/UserInfoDTO.java
+++ b/src/main/java/com/ripple/BE/user/dto/UserInfoDTO.java
@@ -15,4 +15,5 @@ public record UserInfoDTO(
         String job,
         Long currentStreak,
         Level level,
-        Long quizCorrectRate) {}
+        Long quizCorrectRate,
+        Boolean isLevelTestCompleted) {}

--- a/src/main/java/com/ripple/BE/user/dto/response/UserCompletedResponse.java
+++ b/src/main/java/com/ripple/BE/user/dto/response/UserCompletedResponse.java
@@ -1,0 +1,25 @@
+package com.ripple.BE.user.dto.response;
+
+import com.ripple.BE.user.dto.UserCompletedDTO;
+import lombok.Builder;
+
+@Builder
+public record UserCompletedResponse(
+        long userId,
+        long beginnerCompletedCount,
+        long intermediateCompletedCount,
+        long advancedCompletedCount,
+        long totalConceptCompletedCount,
+        long quizCount) {
+    public static UserCompletedResponse toUserCompletedResponse(
+            final UserCompletedDTO userCompletedDTO) {
+        return UserCompletedResponse.builder()
+                .userId(userCompletedDTO.userId())
+                .beginnerCompletedCount(userCompletedDTO.beginnerCompletedCount())
+                .intermediateCompletedCount(userCompletedDTO.intermediateCompletedCount())
+                .advancedCompletedCount(userCompletedDTO.advancedCompletedCount())
+                .totalConceptCompletedCount(userCompletedDTO.totalConceptCompletedCount())
+                .quizCount(userCompletedDTO.quizCount())
+                .build();
+    }
+}

--- a/src/main/java/com/ripple/BE/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/ripple/BE/user/dto/response/UserInfoResponse.java
@@ -15,7 +15,8 @@ public record UserInfoResponse(
         String job,
         Long currentStreak,
         Level level,
-        Long quizCorrectRate) {
+        Long quizCorrectRate,
+        Boolean isLevelTestCompleted) {
 
     public static UserInfoResponse toUserInfoResponse(UserInfoDTO userInfoDTO) {
         return new UserInfoResponse(
@@ -28,6 +29,7 @@ public record UserInfoResponse(
                 userInfoDTO.job(),
                 userInfoDTO.currentStreak(),
                 userInfoDTO.level(),
-                userInfoDTO.quizCorrectRate());
+                userInfoDTO.quizCorrectRate(),
+                userInfoDTO.isLevelTestCompleted());
     }
 }

--- a/src/main/java/com/ripple/BE/user/service/MyPageService.java
+++ b/src/main/java/com/ripple/BE/user/service/MyPageService.java
@@ -1,5 +1,7 @@
 package com.ripple.BE.user.service;
 
+import static com.ripple.BE.user.exception.errorcode.UserErrorCode.*;
+
 import com.ripple.BE.learning.domain.concept.Concept;
 import com.ripple.BE.learning.domain.quiz.Quiz;
 import com.ripple.BE.learning.dto.ConceptListDTO;
@@ -23,7 +25,11 @@ import com.ripple.BE.post.repository.postscrap.PostScrapRepository;
 import com.ripple.BE.term.domain.Term;
 import com.ripple.BE.term.dto.TermListDTO;
 import com.ripple.BE.term.repository.TermScrapRepository;
+import com.ripple.BE.user.domain.User;
 import com.ripple.BE.user.domain.type.Level;
+import com.ripple.BE.user.dto.UserCompletedDTO;
+import com.ripple.BE.user.exception.UserException;
+import com.ripple.BE.user.repository.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +52,7 @@ public class MyPageService {
     private final ConceptScrapRepository conceptScrapRepository;
     private final TermScrapRepository termScrapRepository;
     private final NewsScrapRepository newsScrapRepository;
+    private final UserRepository userRepository;
 
     public PostListDTO getMyPosts(final long userId) {
 
@@ -122,5 +129,25 @@ public class MyPageService {
     public NewsListDTO getMyScrapNews(final long userId) {
         List<News> news = newsScrapRepository.findNewsScrappedByUser(userId);
         return NewsListDTO.toNewsListDTO(news);
+    }
+
+    public UserCompletedDTO getCompletedConceptAndQuizCount(final long userId) {
+        User user =
+                userRepository.findById(userId).orElseThrow(() -> new UserException(USER_NOT_FOUND));
+
+        long beginnerCompletedCount = user.getBeginnerCompletedCount();
+        long intermediateCompletedCount = user.getIntermediateCompletedCount();
+        long advancedCompletedCount = user.getAdvancedCompletedCount();
+        long totalConceptCompletedCount =
+                beginnerCompletedCount + intermediateCompletedCount + advancedCompletedCount;
+
+        return UserCompletedDTO.builder()
+                .userId(userId)
+                .beginnerCompletedCount(beginnerCompletedCount)
+                .intermediateCompletedCount(intermediateCompletedCount)
+                .advancedCompletedCount(advancedCompletedCount)
+                .totalConceptCompletedCount(totalConceptCompletedCount)
+                .quizCount(user.getQuizCount())
+                .build();
     }
 }

--- a/src/main/java/com/ripple/BE/user/service/UserService.java
+++ b/src/main/java/com/ripple/BE/user/service/UserService.java
@@ -157,6 +157,7 @@ public class UserService {
                 .currentStreak(attendanceService.getCurrentStreak(userId))
                 .level(user.getCurrentLevel())
                 .quizCorrectRate(quizCorrectRate)
+                .isLevelTestCompleted(user.isLevelTestCompleted())
                 .build();
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #25 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 퀘스트 부분에서 사용자 레벨 외에 다른 레벨의 학습이나 퀴즈 진행했을 경우에 일일퀘스트에 반영이 안 되도록 수정
- 퀴즈,학습 몇개했는지 조회하는 api 추가
- 사용자프로필에 레벨테스트 진행여부 추가


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?