### PR TITLE
[Refact] 뉴스 데이터 크롤링 방식 수정 및 학습 데이터 추가 방식 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-devtools'
+    testImplementation 'junit:junit:4.13.1'
 
     //Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/ripple/BE/global/config/AsyncConfig.java
+++ b/src/main/java/com/ripple/BE/global/config/AsyncConfig.java
@@ -1,0 +1,22 @@
+package com.ripple.BE.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean
+    public TaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10); // 스레드 풀의 기본 크기
+        executor.setMaxPoolSize(100); // 스레드 풀의 최대 크기
+        executor.setQueueCapacity(50); // 대기열 크기
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/ripple/BE/learning/service/learningset/LearningAdminService.java
+++ b/src/main/java/com/ripple/BE/learning/service/learningset/LearningAdminService.java
@@ -3,6 +3,7 @@ package com.ripple.BE.learning.service.learningset;
 import com.ripple.BE.global.excel.ExcelUtils;
 import com.ripple.BE.learning.domain.concept.Concept;
 import com.ripple.BE.learning.domain.learningset.LearningSet;
+import com.ripple.BE.learning.domain.learningset.UserLearningSet;
 import com.ripple.BE.learning.domain.quiz.Choice;
 import com.ripple.BE.learning.domain.quiz.Quiz;
 import com.ripple.BE.learning.dto.ConceptDTO;
@@ -11,7 +12,12 @@ import com.ripple.BE.learning.dto.QuizDTO;
 import com.ripple.BE.learning.exception.LearningException;
 import com.ripple.BE.learning.exception.errorcode.LearningErrorCode;
 import com.ripple.BE.learning.repository.learningSet.LearningSetRepository;
+import com.ripple.BE.learning.repository.learningSet.UserLearningSetRepository;
 import com.ripple.BE.learning.repository.quiz.QuizRepository;
+import com.ripple.BE.user.domain.User;
+import com.ripple.BE.user.domain.type.Level;
+import com.ripple.BE.user.repository.UserRepository;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -30,8 +36,10 @@ public class LearningAdminService {
     private static final int CONCEPT_SHEET_INDEX = 1;
     private static final int QUIZ_SHEET_INDEX = 2;
 
+    private final UserLearningSetRepository userLearningSetRepository;
     private final LearningSetRepository learningSetRepository;
     private final QuizRepository quizRepository;
+    private final UserRepository userRepository;
 
     /** 엑셀 파일로부터 학습 세트를 생성 */
     @Transactional
@@ -68,6 +76,8 @@ public class LearningAdminService {
             addQuizzesToLearningSets(FILE_PATH, newLearningSetMap);
 
             learningSetRepository.saveAll(newLearningSets);
+
+            addUserLearningSetsForNewLearningSets(newLearningSets);
 
         } catch (Exception e) {
             log.error("Failed to save learning set by excel", e);
@@ -126,5 +136,33 @@ public class LearningAdminService {
                                                 choice.setQuiz(quiz);
                                             });
                         });
+    }
+
+    @Transactional
+    public void addUserLearningSetsForNewLearningSets(List<LearningSet> newLearningSets) {
+        log.info("새 학습 세트에 대한 사용자 학습 세트 추가 시작...");
+
+        List<User> users = userRepository.findAll();
+
+        List<UserLearningSet> userLearningSetsToSave =
+                users.stream()
+                        .flatMap(user -> generateUserLearningSets(user, newLearningSets).stream())
+                        .collect(Collectors.toList());
+
+        if (!userLearningSetsToSave.isEmpty()) {
+            userLearningSetRepository.saveAll(userLearningSetsToSave);
+        }
+
+        log.info("사용자 학습 세트 추가 완료.");
+    }
+
+    private List<UserLearningSet> generateUserLearningSets(
+            User user, List<LearningSet> learningSets) {
+        return learningSets.stream()
+                .flatMap(
+                        learningSet ->
+                                Arrays.stream(Level.values())
+                                        .map(level -> UserLearningSet.toUserLearningSet(user, learningSet, level)))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/ripple/BE/news/service/NewsCrawlerService.java
+++ b/src/main/java/com/ripple/BE/news/service/NewsCrawlerService.java
@@ -1,0 +1,52 @@
+package com.ripple.BE.news.service;
+
+import com.ripple.BE.news.crawler.NewsCrawler;
+import com.ripple.BE.news.domain.News;
+import com.ripple.BE.news.dto.NewsDTO;
+import com.ripple.BE.news.repository.news.NewsJdbcRepository;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class NewsCrawlerService {
+
+    private final NewsJdbcRepository newsJdbcRepository;
+
+    @Async
+    @Transactional
+    public CompletableFuture<Void> crawl(NewsCrawler crawler) {
+
+        List<NewsDTO> newsList = crawler.crawl();
+        List<News> filteredNews = filterOutDuplicateUrls(newsList);
+        saveNewsBatch(filteredNews);
+
+        return CompletableFuture.completedFuture(null);
+    }
+
+    public List<News> filterOutDuplicateUrls(List<NewsDTO> newsList) {
+        if (newsList.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> urls = newsList.stream().map(NewsDTO::url).toList();
+        List<String> existingUrls = newsJdbcRepository.findExistingUrls(urls);
+
+        return newsList.stream()
+                .filter(dto -> !existingUrls.contains(dto.url()))
+                .map(News::toNewsEntity)
+                .toList();
+    }
+
+    public void saveNewsBatch(List<News> newsList) {
+        if (newsList.isEmpty()) {
+            return;
+        }
+
+        newsJdbcRepository.saveAllNewsByJdbcTemplate(newsList);
+    }
+}

--- a/src/main/java/com/ripple/BE/news/service/NewsService.java
+++ b/src/main/java/com/ripple/BE/news/service/NewsService.java
@@ -17,6 +17,7 @@ import com.ripple.BE.user.domain.User;
 import com.ripple.BE.user.service.AttendanceService;
 import com.ripple.BE.user.service.UserService;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
@@ -36,6 +37,7 @@ public class NewsService {
     private final NewsScrapRepository newsScrapRepository;
     private final NewsJdbcRepository newsJdbcRepository;
 
+    private final NewsCrawlerService newsCrawlerService;
     private final UserService userService;
     private final List<NewsCrawler> crawlers;
     private final AttendanceService attendanceService;
@@ -99,37 +101,11 @@ public class NewsService {
     }
 
     // 하루 한 번 뉴스 크롤링, 실제 배포시는 짧은 주기로 변경 필요
-    @Scheduled(cron = "0 0 0 * * *")
-    @Transactional
-    public void fetchAndSaveAllNews() {
-        for (NewsCrawler crawler : crawlers) {
-            List<NewsDTO> newsList = crawler.crawl();
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정 실행
+    public void fetchAndSaveAllNewsAsync() {
+        List<CompletableFuture<Void>> futures =
+                crawlers.stream().map(newsCrawlerService::crawl).toList();
 
-            List<News> filteredNews = filterOutDuplicateUrls(newsList);
-
-            saveNewsBatch(filteredNews);
-        }
-    }
-
-    private List<News> filterOutDuplicateUrls(List<NewsDTO> newsList) {
-        if (newsList.isEmpty()) {
-            return List.of();
-        }
-
-        List<String> urls = newsList.stream().map(NewsDTO::url).toList();
-        List<String> existingUrls = newsJdbcRepository.findExistingUrls(urls);
-
-        return newsList.stream()
-                .filter(dto -> !existingUrls.contains(dto.url()))
-                .map(News::toNewsEntity)
-                .toList();
-    }
-
-    private void saveNewsBatch(List<News> newsList) {
-        if (newsList.isEmpty()) {
-            return;
-        }
-
-        newsJdbcRepository.saveAllNewsByJdbcTemplate(newsList);
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join(); // 모든 크롤링이 끝날 때까지 대기
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #72 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 뉴스 데이터 크롤링 수행 방식 변경
- 크롤러가 멀티스레딩을 통한 비동기 처리를 통해 병렬 수행 방식으로 동작하도록 변경 

### 학습 데이터 추가 방식 변경
- 학습 데이터를 추가할 때 새로운 학습 세트의 경우 userLearningSet 생성 후 모든 사용자에게 추가할 수 있도록 수정




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?