### PR TITLE
[fix] 게시글 삭제 시 Comment, CommentLike 제약 조건 오류 및 CORS 이슈 해결

### DIFF
--- a/src/main/java/com/ripple/BE/global/config/WebConfig.java
+++ b/src/main/java/com/ripple/BE/global/config/WebConfig.java
@@ -17,6 +17,6 @@ public class WebConfig implements WebMvcConfigurer {
                         "http://localhost:8080",
                         "http://api.cotato-ripple.kro.kr/",
                         "https://api.cotato-ripple.kro.kr/")
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH");
     }
 }

--- a/src/main/java/com/ripple/BE/post/persistence/CommentLikeRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/CommentLikeRepository.java
@@ -19,4 +19,6 @@ public interface CommentLikeRepository {
     void delete(final CommentLike commentLike);
 
     void deleteAllByCommentId(final long commentId);
+
+    void deleteAllByPostId(final long postId);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/CommentRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/CommentRepository.java
@@ -24,4 +24,6 @@ public interface CommentRepository {
 
     // 댓글 작성자 ID로 댓글을 조회한다.
     List<Comment> findAllByCommenterId(final long userId);
+
+    void deleteAllByPostId(final long postId);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/impl/post/CommentLikeRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/impl/post/CommentLikeRepositoryImpl.java
@@ -49,4 +49,9 @@ public class CommentLikeRepositoryImpl implements CommentLikeRepository {
     public void deleteAllByCommentId(final long commentId) {
         commentLikeJpaRepository.deleteAllByCommentId(commentId);
     }
+
+    @Override
+    public void deleteAllByPostId(final long postId) {
+        commentLikeJpaRepository.deleteAllByPostId(postId);
+    }
 }

--- a/src/main/java/com/ripple/BE/post/persistence/impl/post/CommentRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/impl/post/CommentRepositoryImpl.java
@@ -70,4 +70,9 @@ public class CommentRepositoryImpl implements CommentRepository {
     public List<Comment> findAllByCommenterId(final long userId) {
         return commentJpaRepository.findAllByCommenterId(userId).stream().map(Comment::from).toList();
     }
+
+    @Override
+    public void deleteAllByPostId(final long postId) {
+        commentJpaRepository.deleteAllByPostId(postId);
+    }
 }

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/comment/CommentJpaRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/comment/CommentJpaRepository.java
@@ -18,4 +18,6 @@ public interface CommentJpaRepository
     List<CommentJpaEntity> findAllByCommenterId(Long userId);
 
     List<CommentJpaEntity> findChildrenByParentId(Long parentId);
+
+    void deleteAllByPostId(Long postId);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/commentlike/CommentLikeJpaRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/commentlike/CommentLikeJpaRepository.java
@@ -1,8 +1,11 @@
 package com.ripple.BE.post.persistence.jpa.repository.commentlike;
 
 import com.ripple.BE.post.persistence.jpa.entity.CommentLikeJpaEntity;
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CommentLikeJpaRepository
         extends JpaRepository<CommentLikeJpaEntity, Long>, CommentLikeQueryRepository {
@@ -12,4 +15,8 @@ public interface CommentLikeJpaRepository
     boolean existsByCommentIdAndUserId(long commentId, long userId);
 
     void deleteAllByCommentId(long commentId);
+
+    @Modifying
+    @Query("DELETE FROM CommentLikeJpaEntity cl WHERE cl.comment.post.id = :postId")
+    void deleteAllByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/ripple/BE/post/service/impl/post/PostCommandService.java
+++ b/src/main/java/com/ripple/BE/post/service/impl/post/PostCommandService.java
@@ -8,6 +8,8 @@ import com.ripple.BE.image.exception.ImageException;
 import com.ripple.BE.image.repository.ImageRepository;
 import com.ripple.BE.post.domain.post.Post;
 import com.ripple.BE.post.exception.PostException;
+import com.ripple.BE.post.persistence.CommentLikeRepository;
+import com.ripple.BE.post.persistence.CommentRepository;
 import com.ripple.BE.post.persistence.PostLikeRepository;
 import com.ripple.BE.post.persistence.PostRepository;
 import com.ripple.BE.post.persistence.PostScrapRepository;
@@ -32,6 +34,8 @@ public class PostCommandService implements PostCommandUseCase {
     private final ImageRepository imageRepository;
     private final PostLikeRepository postLikeRepository;
     private final PostScrapRepository postScrapRepository;
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
 
     private final UserService userService;
     private final PostJpaRepository postJpaRepository;
@@ -104,6 +108,10 @@ public class PostCommandService implements PostCommandUseCase {
         imageRepository.deleteAll(imageList);
         postScrapRepository.deleteAllByPostId(post.getId());
         postLikeRepository.deleteAllByPostId(post.getId());
+        commentLikeRepository.deleteAllByPostId(post.getId());
+
+        commentRepository.deleteAllByPostId(post.getId());
+
         postRepository.delete(post);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #86

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 게시글 삭제 시 연관된 댓글(Comment)과 댓글 좋아요(CommentLike) 삭제 시 도메인 객체 생성으로 인한 예외가 발생하던 문제를 해결했습니다.
  - 삭제 순서: Image → Scrap → Like → CommentLike → Comment → Post
- CORS 오류 해결을 위한 PATCH 메서드 허용 설정 추가

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?