### PR TITLE
[Feat] 에러 로그 파일 분리 저장 및 Discord 알림 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ configurations {
 repositories {
     mavenCentral()
     maven { url 'https://repo.spring.io/milestone' } // Spring AI 저장소 추가
+    maven { url 'https://jitpack.io' } // JitPack 저장소 추가
 }
 
 dependencies {
@@ -99,6 +100,8 @@ dependencies {
     // SSE
     implementation 'org.springframework.boot:spring-boot-starter-web-services'
 
+    // discord
+    implementation 'com.github.napstr:logback-discord-appender:1.0.0'
 }
 
 clean {	delete file('src/main/generated')}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - "8080:8080"
     environment:
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-prod}
+    volumes:
+      - ./logs:/app/logs
     depends_on:
       - redis
 

--- a/src/main/java/com/ripple/BE/auth/controller/AuthController.java
+++ b/src/main/java/com/ripple/BE/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/auth")
 @Tag(name = "Auth", description = "인증 API")
+@Slf4j
 public class AuthController {
 
     private final AuthService authService;
@@ -47,5 +49,17 @@ public class AuthController {
         String token = authService.BasicLogin(request);
 
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(token));
+    }
+
+    @GetMapping("/log/error-test")
+    public String generateErrorLog() {
+        try {
+            int result = 10 / 0; // 고의적인 예외 발생
+        } catch (ArithmeticException e) {
+            log.error("🚨 운영 환경 에러 로그 테스트 발생", e);
+            throw new RuntimeException("테스트용 RuntimeException 발생", e);
+        }
+
+        return "이 메시지는 도달하지 않습니다.";
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,4 +1,4 @@
-# 로컬 환경에서 사용할 설정 파일
+# 배포 환경에서 사용할 설정 파일
 spring:
   config:
     activate:
@@ -45,6 +45,8 @@ cloud:
 logging:
   level:
     root: INFO
+  discord-error:
+    webhook-url: ${DISCORD_ERROR_WEBHOOK_URL}
 
 Swagger:
   server:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <!-- 공통 로그 패턴 -->
+    <property name="LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %-5level [%logger{36}] - %msg%n"/>
+
+    <!-- 로컬 환경 설정 -->
+    <springProfile name="local">
+        <property name="LOG_PATH" value="./logs" />
+    </springProfile>
+
+    <!-- 운영 환경 설정 -->
+    <springProfile name="prod">
+        <property name="LOG_PATH" value="/app/logs" />
+        <springProperty name="DISCORD_ERROR_WEBHOOK_URL"
+                        source="logging.discord-error.webhook-url"/>
+    </springProfile>
+
+    <!-- 콘솔 출력 공통 Appender -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- ✅ 운영 환경 전용: 에러 로그 파일 Appender -->
+    <springProfile name="prod">
+        <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/error.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/error.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>ERROR</level>
+            </filter>
+        </appender>
+    </springProfile>
+
+    <!-- ✅ 운영 환경 전용: Discord Webhook Appender -->
+    <springProfile name="prod">
+        <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
+            <webhookUri>${DISCORD_ERROR_WEBHOOK_URL}</webhookUri>
+            <layout class="ch.qos.logback.classic.PatternLayout">
+                <pattern>
+                    \n[🚨 ERROR LOG] ========================================
+                    \n%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [%logger{2}.%M:%L] - %ex{short}%n
+                </pattern>
+            </layout>
+            <username>🚨 Ripple 서버 에러 알림</username>
+            <tts>false</tts>
+        </appender>
+
+        <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="DISCORD" />
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>ERROR</level>
+            </filter>
+        </appender>
+    </springProfile>
+
+    <!-- com.ripple 로그 설정: 운영 환경일 경우만 파일/디스코드 추가 -->
+    <logger name="com.ripple" level="ERROR" additivity="false">
+        <springProfile name="prod">
+            <appender-ref ref="ERROR_FILE" />
+            <appender-ref ref="ASYNC_DISCORD" />
+        </springProfile>
+    </logger>
+
+    <!-- 전체 로그 콘솔 출력 (공통) -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #108

## 📝작업 내용


> 운영 환경에서 발생하는 에러 로그를 효과적으로 추적하고, 실시간 알림을 통해 빠르게 대응할 수 있도록 로그 시스템을 개선했습니다.

- logback-spring.xml에 환경 분기(local/prod) 기반 로깅 설정 추가
   - prod 환경: error.log 생성 + 날짜별 롤링 + Discord 알림 전송
   - local 환경: 콘솔 출력만 수행
- logback-discord-appender 라이브러리 적용 (JitPack 저장소 등록 포함)
- application-prod.yml에 logging.discord-error.webhook-url 프로퍼티 등록
- docker-compose.yml에 로그 파일 외부 저장을 위한 ./logs:/app/logs 볼륨 마운트 설정
- 테스트용 에러 발생 API (/log/error-test) 추가 (AuthController.java)
   - 예외를 고의로 발생시켜 로그 파일 및 디스코드 전송 확인 가능

<img width="826" alt="image" src="https://github.com/user-attachments/assets/5a1e6581-7655-4e11-a786-9e1e7e689b55" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?