### PR TITLE
[Feat] 학습 세트 별 완료한 퀴즈 조회 (#113)

### DIFF
--- a/src/main/java/com/ripple/BE/learning/application/quiz/QuizService.java
+++ b/src/main/java/com/ripple/BE/learning/application/quiz/QuizService.java
@@ -2,9 +2,12 @@ package com.ripple.BE.learning.application.quiz;
 
 import static com.ripple.BE.learning.exception.errorcode.LearningErrorCode.*;
 
+import com.ripple.BE.learning.application.learningset.LearningSetService;
+import com.ripple.BE.learning.domain.learningset.UserLearningSet;
 import com.ripple.BE.learning.domain.quiz.FailQuiz;
 import com.ripple.BE.learning.domain.quiz.Quiz;
 import com.ripple.BE.learning.domain.quiz.QuizScrap;
+import com.ripple.BE.learning.dto.response.quiz.QuizCompletionDTO;
 import com.ripple.BE.learning.dto.response.quiz.QuizResponseDTO;
 import com.ripple.BE.learning.dto.response.quiz.QuizResultResponseDTO;
 import com.ripple.BE.learning.dto.response.quiz.RandomQuizResponseDTO;
@@ -13,6 +16,7 @@ import com.ripple.BE.learning.exception.LearningException;
 import com.ripple.BE.learning.exception.errorcode.LearningErrorCode;
 import com.ripple.BE.learning.persistence.QuizRepository;
 import com.ripple.BE.learning.persistence.QuizScrapRepository;
+import com.ripple.BE.learning.persistence.UserLearningSetRepository;
 import com.ripple.BE.user.domain.type.Level;
 import com.ripple.BE.user.service.UserProgressManager;
 import java.util.List;
@@ -30,9 +34,12 @@ public class QuizService {
 
     private final QuizRepository quizRepository;
     private final QuizScrapRepository quizScrapRepository;
+    private final UserLearningSetRepository userLearningSetRepository;
 
     private final UserProgressManager userProgressManager;
     private final QuizSessionCacheManager quizSessionCacheManager;
+
+    private final LearningSetService learningSetService;
 
     /**
      * 퀴즈 시작
@@ -183,5 +190,24 @@ public class QuizService {
                         .orElseThrow(() -> new LearningException(LearningErrorCode.QUIZ_NOT_FOUND));
 
         return QuizResponseDTO.from(quiz);
+    }
+
+    public QuizCompletionDTO getCompleteQuizzesByLearningSet(
+            final long userId, final long learningSetId) {
+
+        boolean beginnerCompleted =
+                getUserLearningSet(userId, learningSetId, Level.BEGINNER).isQuizCompleted();
+        boolean intermediateCompleted =
+                getUserLearningSet(userId, learningSetId, Level.INTERMEDIATE).isQuizCompleted();
+        boolean advancedCompleted =
+                getUserLearningSet(userId, learningSetId, Level.ADVANCED).isQuizCompleted();
+
+        return QuizCompletionDTO.of(beginnerCompleted, intermediateCompleted, advancedCompleted);
+    }
+
+    private UserLearningSet getUserLearningSet(long userId, long learningSetId, Level level) {
+        return userLearningSetRepository
+                .findByUserIdAndLearningSetIdAndLevel(userId, learningSetId, level)
+                .orElseThrow(() -> new LearningException(LEARNING_SET_NOT_FOUND));
     }
 }

--- a/src/main/java/com/ripple/BE/learning/application/quiz/QuizService.java
+++ b/src/main/java/com/ripple/BE/learning/application/quiz/QuizService.java
@@ -192,22 +192,36 @@ public class QuizService {
         return QuizResponseDTO.from(quiz);
     }
 
+    /** 사용자가 완료한 퀴즈 레벨별 조회 */
     public QuizCompletionDTO getCompleteQuizzesByLearningSet(
             final long userId, final long learningSetId) {
 
-        boolean beginnerCompleted =
-                getUserLearningSet(userId, learningSetId, Level.BEGINNER).isQuizCompleted();
-        boolean intermediateCompleted =
-                getUserLearningSet(userId, learningSetId, Level.INTERMEDIATE).isQuizCompleted();
-        boolean advancedCompleted =
-                getUserLearningSet(userId, learningSetId, Level.ADVANCED).isQuizCompleted();
+        List<UserLearningSet> userLearningSetList =
+                userLearningSetRepository.findByUserIdAndLearningSetId(userId, learningSetId);
+
+        if (userLearningSetList.isEmpty()) {
+            throw new LearningException(LEARNING_SET_NOT_FOUND);
+        }
+
+        boolean beginnerCompleted = false;
+        boolean intermediateCompleted = false;
+        boolean advancedCompleted = false;
+        for (UserLearningSet userLearningSet : userLearningSetList) {
+            Level level = userLearningSet.getLevel();
+
+            switch (level) {
+                case BEGINNER:
+                    beginnerCompleted = userLearningSet.isQuizCompleted();
+                    break;
+                case INTERMEDIATE:
+                    intermediateCompleted = userLearningSet.isQuizCompleted();
+                    break;
+                case ADVANCED:
+                    advancedCompleted = userLearningSet.isQuizCompleted();
+                    break;
+            }
+        }
 
         return QuizCompletionDTO.of(beginnerCompleted, intermediateCompleted, advancedCompleted);
-    }
-
-    private UserLearningSet getUserLearningSet(long userId, long learningSetId, Level level) {
-        return userLearningSetRepository
-                .findByUserIdAndLearningSetIdAndLevel(userId, learningSetId, level)
-                .orElseThrow(() -> new LearningException(LEARNING_SET_NOT_FOUND));
     }
 }

--- a/src/main/java/com/ripple/BE/learning/controller/QuizController.java
+++ b/src/main/java/com/ripple/BE/learning/controller/QuizController.java
@@ -2,6 +2,7 @@ package com.ripple.BE.learning.controller;
 
 import com.ripple.BE.global.dto.response.ApiResponse;
 import com.ripple.BE.learning.application.quiz.QuizService;
+import com.ripple.BE.learning.dto.response.quiz.QuizCompletionDTO;
 import com.ripple.BE.learning.dto.response.quiz.QuizResponseDTO;
 import com.ripple.BE.learning.dto.response.quiz.QuizResultResponseDTO;
 import com.ripple.BE.learning.dto.response.quiz.RandomQuizResponseDTO;
@@ -129,8 +130,9 @@ public class QuizController {
             @AuthenticationPrincipal CustomUserDetails currentUser,
             @PathVariable("learningSetId") long learningSetId) {
 
-        // QuizResponseDTO quizResponseDTO =
-        // quizService.getCompleteQuizzesByLearningSet(currentUser.getId(), learningSetId);
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(ApiResponse.EMPTY_RESPONSE));
+        QuizCompletionDTO completeQuizzesByLearningSet =
+                quizService.getCompleteQuizzesByLearningSet(currentUser.getId(), learningSetId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.from(ApiResponse.from(completeQuizzesByLearningSet)));
     }
 }

--- a/src/main/java/com/ripple/BE/learning/controller/QuizController.java
+++ b/src/main/java/com/ripple/BE/learning/controller/QuizController.java
@@ -120,4 +120,17 @@ public class QuizController {
         QuizResultResponseDTO quizResultResponseDTO = quizService.retryScrapQuiz(quizId, answerIndex);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(quizResultResponseDTO));
     }
+
+    @GetMapping("/{learningSetId}/quizzes")
+    @Operation(
+            summary = "학습 세트 별 완료한 퀴즈 조회",
+            description = "학습 세트 별로 완료한 퀴즈를 조회합니다. 학습 세트 ID를 통해 해당 세트에 속한 퀴즈 목록을 가져옵니다.")
+    public ResponseEntity<ApiResponse<?>> getCompleteQuizzesByLearningSet(
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @PathVariable("learningSetId") long learningSetId) {
+
+        // QuizResponseDTO quizResponseDTO =
+        // quizService.getCompleteQuizzesByLearningSet(currentUser.getId(), learningSetId);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(ApiResponse.EMPTY_RESPONSE));
+    }
 }

--- a/src/main/java/com/ripple/BE/learning/dto/response/quiz/QuizCompletionDTO.java
+++ b/src/main/java/com/ripple/BE/learning/dto/response/quiz/QuizCompletionDTO.java
@@ -1,0 +1,7 @@
+package com.ripple.BE.learning.dto.response.quiz;
+
+public record QuizCompletionDTO(boolean beginner, boolean intermediate, boolean advanced) {
+    public static QuizCompletionDTO of(boolean beginner, boolean intermediate, boolean advanced) {
+        return new QuizCompletionDTO(beginner, intermediate, advanced);
+    }
+}

--- a/src/main/java/com/ripple/BE/learning/persistence/UserLearningSetRepository.java
+++ b/src/main/java/com/ripple/BE/learning/persistence/UserLearningSetRepository.java
@@ -17,4 +17,6 @@ public interface UserLearningSetRepository {
     UserLearningSet save(final UserLearningSet userLearningSet);
 
     List<UserLearningSet> findAll();
+
+    List<UserLearningSet> findByUserIdAndLearningSetId(final long userId, final long learningSetId);
 }

--- a/src/main/java/com/ripple/BE/learning/persistence/impl/UserLearningSetRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/learning/persistence/impl/UserLearningSetRepositoryImpl.java
@@ -54,4 +54,11 @@ public class UserLearningSetRepositoryImpl implements UserLearningSetRepository 
                 .map(UserLearningSetJpaEntity::toModel)
                 .toList();
     }
+
+    @Override
+    public List<UserLearningSet> findByUserIdAndLearningSetId(long userId, long learningSetId) {
+        return userLearningSetJpaRepository.findByUserIdAndLearningSetId(userId, learningSetId).stream()
+                .map(UserLearningSetJpaEntity::toModel)
+                .toList();
+    }
 }

--- a/src/main/java/com/ripple/BE/learning/persistence/jpa/repository/learningset/UserLearningSetJpaRepository.java
+++ b/src/main/java/com/ripple/BE/learning/persistence/jpa/repository/learningset/UserLearningSetJpaRepository.java
@@ -21,4 +21,6 @@ public interface UserLearningSetJpaRepository
                     + "WHERE lsc.userId = :userId AND lsc.level = :level")
     List<UserLearningSetJpaEntity> findByUserIdAndLevel(
             @Param("userId") long userId, @Param("level") Level level);
+
+    List<UserLearningSetJpaEntity> findByUserIdAndLearningSetId(Long userId, Long learningSetId);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #113

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 학습 세트 별 완료한 퀴즈를 조회하는 api를 추가했습니다


## 💬리뷰 요구사항(선택)

> 테스트하면서 발견한건데 유저가 처음 회원가입 후에 "학습>퀴즈" 순으로 진행하면 문제가 없는데 혹시 퀴즈만 먼저 진행할 수 있다면?? user_learning_sets가 생성이 안되어 있어서 에러가 나더라구요!! 이것도 내일 확인해보면 좋을것같습니다