### PR TITLE
[Feat] 회원 탈퇴 구현 (#107)

### DIFF
--- a/src/main/java/com/ripple/BE/auth/controller/AuthController.java
+++ b/src/main/java/com/ripple/BE/auth/controller/AuthController.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,7 +27,7 @@ public class AuthController {
     private final AuthService authService;
 
     @Operation(summary = "카카오 로그인", description = "카카오 로그인을 진행합니다.")
-    @GetMapping("/login/kakao")
+    @PostMapping("/login/kakao")
     public ResponseEntity<ApiResponse<Object>> kakaoLogin(@RequestParam String code) {
 
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/ripple/BE/auth/controller/AuthControllerV2.java
+++ b/src/main/java/com/ripple/BE/auth/controller/AuthControllerV2.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,7 +21,7 @@ public class AuthControllerV2 {
     private final AuthService authService;
 
     @Operation(summary = "카카오 로그인 (v2)", description = "네이티브 앱에서 카카오 로그인을 진행합니다.")
-    @GetMapping("/login/kakao")
+    @PostMapping("/login/kakao")
     public ResponseEntity<ApiResponse<Object>> kakaoLogin(@RequestParam String accessToken) {
 
         String jwtToken = authService.kakaoLoginV2(accessToken);

--- a/src/main/java/com/ripple/BE/image/persistence/ImageRepository.java
+++ b/src/main/java/com/ripple/BE/image/persistence/ImageRepository.java
@@ -19,4 +19,6 @@ public interface ImageRepository {
     void saveAll(List<Image> images);
 
     void deleteAll(List<Image> images);
+
+    void deleteById(Long id);
 }

--- a/src/main/java/com/ripple/BE/image/persistence/ImageRepository.java
+++ b/src/main/java/com/ripple/BE/image/persistence/ImageRepository.java
@@ -21,4 +21,6 @@ public interface ImageRepository {
     void deleteAll(List<Image> images);
 
     void deleteById(Long id);
+
+    void deleteAllByPostIdIn(List<Long> postIds);
 }

--- a/src/main/java/com/ripple/BE/image/persistence/impl/ImageRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/image/persistence/impl/ImageRepositoryImpl.java
@@ -51,4 +51,9 @@ public class ImageRepositoryImpl implements ImageRepository {
         List<ImageJpaEntity> imageEntities = images.stream().map(ImageJpaEntity::from).toList();
         imageJpaRepository.deleteAll(imageEntities);
     }
+
+    @Override
+    public void deleteById(Long id) {
+        imageJpaRepository.deleteById(id);
+    }
 }

--- a/src/main/java/com/ripple/BE/image/persistence/impl/ImageRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/image/persistence/impl/ImageRepositoryImpl.java
@@ -56,4 +56,9 @@ public class ImageRepositoryImpl implements ImageRepository {
     public void deleteById(Long id) {
         imageJpaRepository.deleteById(id);
     }
+
+    @Override
+    public void deleteAllByPostIdIn(List<Long> postIds) {
+        imageJpaRepository.deleteAllByPostIdIn(postIds);
+    }
 }

--- a/src/main/java/com/ripple/BE/image/persistence/jpa/repository/ImageJpaRepository.java
+++ b/src/main/java/com/ripple/BE/image/persistence/jpa/repository/ImageJpaRepository.java
@@ -12,4 +12,6 @@ public interface ImageJpaRepository extends JpaRepository<ImageJpaEntity, Long> 
     Optional<ImageJpaEntity> findByS3InfoUrl(String url);
 
     List<ImageJpaEntity> findByPostId(Long postId);
+
+    void deleteById(Long id);
 }

--- a/src/main/java/com/ripple/BE/image/persistence/jpa/repository/ImageJpaRepository.java
+++ b/src/main/java/com/ripple/BE/image/persistence/jpa/repository/ImageJpaRepository.java
@@ -14,4 +14,6 @@ public interface ImageJpaRepository extends JpaRepository<ImageJpaEntity, Long> 
     List<ImageJpaEntity> findByPostId(Long postId);
 
     void deleteById(Long id);
+
+    void deleteAllByPostIdIn(List<Long> postIds);
 }

--- a/src/main/java/com/ripple/BE/learning/persistence/ConceptScrapRepository.java
+++ b/src/main/java/com/ripple/BE/learning/persistence/ConceptScrapRepository.java
@@ -17,4 +17,6 @@ public interface ConceptScrapRepository {
     void delete(final ConceptScrap conceptScrap);
 
     List<Concept> findConceptsScrappedByUserAndLevel(final long userId, final Level level);
+
+    void deleteAllByUserId(final long userId);
 }

--- a/src/main/java/com/ripple/BE/learning/persistence/FailQuizRepository.java
+++ b/src/main/java/com/ripple/BE/learning/persistence/FailQuizRepository.java
@@ -6,4 +6,6 @@ import java.util.List;
 public interface FailQuizRepository {
 
     void saveAll(List<FailQuiz> failQuizzes);
+
+    void deleteAllByUserId(final long userId);
 }

--- a/src/main/java/com/ripple/BE/learning/persistence/QuizScrapRepository.java
+++ b/src/main/java/com/ripple/BE/learning/persistence/QuizScrapRepository.java
@@ -17,4 +17,6 @@ public interface QuizScrapRepository {
     QuizScrap save(final QuizScrap quizScrap);
 
     List<Quiz> findQuizScrappedByUserIdAndLevel(Long userId, Level level);
+
+    void deleteAllByUserId(final long userId);
 }

--- a/src/main/java/com/ripple/BE/learning/persistence/UserLearningSetRepository.java
+++ b/src/main/java/com/ripple/BE/learning/persistence/UserLearningSetRepository.java
@@ -17,4 +17,6 @@ public interface UserLearningSetRepository {
     UserLearningSet save(final UserLearningSet userLearningSet);
 
     List<UserLearningSet> findAll();
+
+    void deleteAllByUserId(final long userId);
 }

--- a/src/main/java/com/ripple/BE/learning/persistence/impl/ConceptScrapRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/learning/persistence/impl/ConceptScrapRepositoryImpl.java
@@ -48,4 +48,9 @@ public class ConceptScrapRepositoryImpl implements ConceptScrapRepository {
                 .map(ConceptJpaEntity::toModel)
                 .toList();
     }
+
+    @Override
+    public void deleteAllByUserId(final long userId) {
+        conceptScrapJpaRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/com/ripple/BE/learning/persistence/impl/FailQuizRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/learning/persistence/impl/FailQuizRepositoryImpl.java
@@ -21,4 +21,9 @@ public class FailQuizRepositoryImpl implements FailQuizRepository {
         }
         failQuizJpaRepository.saveAll(failQuizzes.stream().map(FailQuizJpaEntity::from).toList());
     }
+
+    @Override
+    public void deleteAllByUserId(final long userId) {
+        failQuizJpaRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/com/ripple/BE/learning/persistence/impl/QuizScrapRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/learning/persistence/impl/QuizScrapRepositoryImpl.java
@@ -46,4 +46,9 @@ public class QuizScrapRepositoryImpl implements QuizScrapRepository {
                 .map(QuizJpaEntity::toModel)
                 .toList();
     }
+
+    @Override
+    public void deleteAllByUserId(final long userId) {
+        quizScrapJpaRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/com/ripple/BE/learning/persistence/impl/UserLearningSetRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/learning/persistence/impl/UserLearningSetRepositoryImpl.java
@@ -54,4 +54,9 @@ public class UserLearningSetRepositoryImpl implements UserLearningSetRepository 
                 .map(UserLearningSetJpaEntity::toModel)
                 .toList();
     }
+
+    @Override
+    public void deleteAllByUserId(final long userId) {
+        userLearningSetJpaRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/com/ripple/BE/learning/persistence/jpa/repository/conceptscrap/ConceptScrapJpaRepository.java
+++ b/src/main/java/com/ripple/BE/learning/persistence/jpa/repository/conceptscrap/ConceptScrapJpaRepository.java
@@ -13,4 +13,6 @@ public interface ConceptScrapJpaRepository
     void deleteByUserIdAndConceptId(Long userId, Long conceptId);
 
     Optional<ConceptScrapJpaEntity> findByUserIdAndConceptId(Long userId, Long conceptId);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/ripple/BE/learning/persistence/jpa/repository/failquiz/FailQuizJpaRepository.java
+++ b/src/main/java/com/ripple/BE/learning/persistence/jpa/repository/failquiz/FailQuizJpaRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface FailQuizJpaRepository extends JpaRepository<FailQuizJpaEntity, Long> {}
+public interface FailQuizJpaRepository extends JpaRepository<FailQuizJpaEntity, Long> {
+    void deleteAllByUserId(Long userId);
+}

--- a/src/main/java/com/ripple/BE/learning/persistence/jpa/repository/learningset/UserLearningSetJpaRepository.java
+++ b/src/main/java/com/ripple/BE/learning/persistence/jpa/repository/learningset/UserLearningSetJpaRepository.java
@@ -21,4 +21,6 @@ public interface UserLearningSetJpaRepository
                     + "WHERE lsc.userId = :userId AND lsc.level = :level")
     List<UserLearningSetJpaEntity> findByUserIdAndLevel(
             @Param("userId") long userId, @Param("level") Level level);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/ripple/BE/learning/persistence/jpa/repository/quizscrap/QuizScrapJpaRepository.java
+++ b/src/main/java/com/ripple/BE/learning/persistence/jpa/repository/quizscrap/QuizScrapJpaRepository.java
@@ -14,4 +14,6 @@ public interface QuizScrapJpaRepository
     Optional<QuizScrapJpaEntity> findByQuizIdAndUserId(Long quizId, Long userId);
 
     void deleteByQuizIdAndUserId(Long quizId, Long userId);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/ripple/BE/news/persistence/NewsScrapRepository.java
+++ b/src/main/java/com/ripple/BE/news/persistence/NewsScrapRepository.java
@@ -16,4 +16,6 @@ public interface NewsScrapRepository {
     void delete(NewsScrap newsScrap); // 스크랩 삭제
 
     List<NewsWithScrapDTO> findNewsScrappedByUser(long userId); // 사용자가 스크랩한 뉴스 목록 조회
+
+    void deleteAllByUserId(long userId); // 사용자 ID로 모든 스크랩 삭제
 }

--- a/src/main/java/com/ripple/BE/news/persistence/impl/NewsScrapRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/news/persistence/impl/NewsScrapRepositoryImpl.java
@@ -42,4 +42,9 @@ public class NewsScrapRepositoryImpl implements NewsScrapRepository {
     public List<NewsWithScrapDTO> findNewsScrappedByUser(long userId) {
         return newsScrapJpaRepository.findNewsScrappedByUser(userId);
     }
+
+    @Override
+    public void deleteAllByUserId(long userId) {
+        newsScrapJpaRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/com/ripple/BE/news/persistence/jpa/repository/newsscrap/NewsScrapJpaRepository.java
+++ b/src/main/java/com/ripple/BE/news/persistence/jpa/repository/newsscrap/NewsScrapJpaRepository.java
@@ -10,4 +10,6 @@ public interface NewsScrapJpaRepository
     Optional<NewsScrapJpaEntity> findByNewsIdAndUserId(long newsId, long userId);
 
     boolean existsByNewsIdAndUserId(long newsId, long userId);
+
+    void deleteAllByUserId(long userId);
 }

--- a/src/main/java/com/ripple/BE/notification/persistence/NotificationRepository.java
+++ b/src/main/java/com/ripple/BE/notification/persistence/NotificationRepository.java
@@ -15,4 +15,6 @@ public interface NotificationRepository {
     long countByUserIdAndIsReadFalse(Long receiverId);
 
     void delete(Notification notification);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/ripple/BE/notification/persistence/NotificationRepository.java
+++ b/src/main/java/com/ripple/BE/notification/persistence/NotificationRepository.java
@@ -16,5 +16,5 @@ public interface NotificationRepository {
 
     void delete(Notification notification);
 
-    void deleteAllByUserId(Long userId);
+    void deleteAllByReceiverId(Long receiverId);
 }

--- a/src/main/java/com/ripple/BE/notification/persistence/impl/NotificationRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/notification/persistence/impl/NotificationRepositoryImpl.java
@@ -41,4 +41,9 @@ public class NotificationRepositoryImpl implements NotificationRepository {
     public void delete(Notification notification) {
         notificationJpaRepository.delete(NotificationJpaEntity.from(notification));
     }
+
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        notificationJpaRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/com/ripple/BE/notification/persistence/impl/NotificationRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/notification/persistence/impl/NotificationRepositoryImpl.java
@@ -43,7 +43,7 @@ public class NotificationRepositoryImpl implements NotificationRepository {
     }
 
     @Override
-    public void deleteAllByUserId(Long userId) {
-        notificationJpaRepository.deleteAllByUserId(userId);
+    public void deleteAllByReceiverId(Long userId) {
+        notificationJpaRepository.deleteAllByReceiverId(userId);
     }
 }

--- a/src/main/java/com/ripple/BE/notification/persistence/jpa/repository/NotificationJpaRepository.java
+++ b/src/main/java/com/ripple/BE/notification/persistence/jpa/repository/NotificationJpaRepository.java
@@ -4,4 +4,6 @@ import com.ripple.BE.notification.persistence.jpa.entity.NotificationJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationJpaRepository
-        extends JpaRepository<NotificationJpaEntity, Long>, NotificationQueryRepository {}
+        extends JpaRepository<NotificationJpaEntity, Long>, NotificationQueryRepository {
+    void deleteAllByUserId(Long userId);
+}

--- a/src/main/java/com/ripple/BE/notification/persistence/jpa/repository/NotificationJpaRepository.java
+++ b/src/main/java/com/ripple/BE/notification/persistence/jpa/repository/NotificationJpaRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationJpaRepository
         extends JpaRepository<NotificationJpaEntity, Long>, NotificationQueryRepository {
-    void deleteAllByUserId(Long userId);
+    void deleteAllByReceiverId(Long userId);
 }

--- a/src/main/java/com/ripple/BE/post/application/PostCommandUseCase.java
+++ b/src/main/java/com/ripple/BE/post/application/PostCommandUseCase.java
@@ -10,4 +10,6 @@ public interface PostCommandUseCase {
     void updatePost(final UpdatePostCommand updatePostCommand);
 
     void deletePost(final long postId, final long userId);
+
+    void deleteAllPostsByUserId(final long userId);
 }

--- a/src/main/java/com/ripple/BE/post/application/impl/post/PostCommandService.java
+++ b/src/main/java/com/ripple/BE/post/application/impl/post/PostCommandService.java
@@ -9,6 +9,7 @@ import com.ripple.BE.image.persistence.ImageRepository;
 import com.ripple.BE.post.application.PostCommandUseCase;
 import com.ripple.BE.post.application.command.CreatePostCommand;
 import com.ripple.BE.post.application.command.UpdatePostCommand;
+import com.ripple.BE.post.domain.comment.Comment;
 import com.ripple.BE.post.domain.post.Post;
 import com.ripple.BE.post.exception.PostException;
 import com.ripple.BE.post.persistence.CommentLikeRepository;
@@ -126,11 +127,14 @@ public class PostCommandService implements PostCommandUseCase {
             return;
         }
         List<Long> postIds = posts.stream().map(Post::getId).toList();
+        List<Long> commentIds =
+                commentRepository.findAllByPostIdIn(postIds).stream().map(Comment::getId).toList();
 
         imageRepository.deleteAllByPostIdIn(postIds);
         postScrapRepository.deleteAllByPostIdIn(postIds);
         postLikeRepository.deleteAllByPostIdIn(postIds);
-        commentLikeRepository.deleteAllByPostIdIn(postIds);
+
+        commentLikeRepository.deleteAllByCommentIdIn(commentIds);
         commentRepository.deleteAllByPostIdIn(postIds);
 
         postRepository.deleteAllByAuthorId(userId);

--- a/src/main/java/com/ripple/BE/post/application/impl/post/PostCommandService.java
+++ b/src/main/java/com/ripple/BE/post/application/impl/post/PostCommandService.java
@@ -118,4 +118,21 @@ public class PostCommandService implements PostCommandUseCase {
 
         postRepository.delete(post);
     }
+
+    @Override
+    public void deleteAllPostsByUserId(final long userId) {
+        List<Post> posts = postRepository.findAllByAuthorId(userId);
+        if (posts.isEmpty()) {
+            return;
+        }
+        List<Long> postIds = posts.stream().map(Post::getId).toList();
+
+        imageRepository.deleteAllByPostIdIn(postIds);
+        postScrapRepository.deleteAllByPostIdIn(postIds);
+        postLikeRepository.deleteAllByPostIdIn(postIds);
+        commentLikeRepository.deleteAllByPostIdIn(postIds);
+        commentRepository.deleteAllByPostIdIn(postIds);
+
+        postRepository.deleteAllByAuthorId(userId);
+    }
 }

--- a/src/main/java/com/ripple/BE/post/persistence/CommentLikeRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/CommentLikeRepository.java
@@ -23,4 +23,6 @@ public interface CommentLikeRepository {
     List<CommentLike> findByUserIdAndCommentIdIn(final long userId, final Set<Long> commentIds);
 
     List<LikeCommentWithPostDTO> findLikedCommentsByUserIdWithPost(long userId);
+
+    void deleteAllByPostIdIn(final List<Long> postIds);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/CommentLikeRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/CommentLikeRepository.java
@@ -25,4 +25,6 @@ public interface CommentLikeRepository {
     List<LikeCommentWithPostDTO> findLikedCommentsByUserIdWithPost(long userId);
 
     void deleteAllByPostIdIn(final List<Long> postIds);
+
+    void deleteAllByUserId(final long userId);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/CommentLikeRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/CommentLikeRepository.java
@@ -24,7 +24,7 @@ public interface CommentLikeRepository {
 
     List<LikeCommentWithPostDTO> findLikedCommentsByUserIdWithPost(long userId);
 
-    void deleteAllByPostIdIn(final List<Long> postIds);
+    void deleteAllByCommentIdIn(final List<Long> commentIds);
 
     void deleteAllByUserId(final long userId);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/CommentRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/CommentRepository.java
@@ -24,4 +24,6 @@ public interface CommentRepository {
     void deleteAllByPostId(final long postId);
 
     void deleteAllByPostIdIn(final List<Long> postIds);
+
+    List<Comment> findAllByPostIdIn(final List<Long> postIds);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/CommentRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/CommentRepository.java
@@ -22,4 +22,6 @@ public interface CommentRepository {
     List<CommentWithPostDTO> findUserCommentsWithPost(final long userId);
 
     void deleteAllByPostId(final long postId);
+
+    void deleteAllByPostIdIn(final List<Long> postIds);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/PostLikeRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/PostLikeRepository.java
@@ -21,4 +21,6 @@ public interface PostLikeRepository {
     void deleteAllByPostId(final long postId);
 
     void deleteAllByPostIdIn(final List<Long> postIds);
+
+    void deleteAllByUserId(final long userId);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/PostLikeRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/PostLikeRepository.java
@@ -19,4 +19,6 @@ public interface PostLikeRepository {
     void save(final PostLike postLike);
 
     void deleteAllByPostId(final long postId);
+
+    void deleteAllByPostIdIn(final List<Long> postIds);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/PostRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/PostRepository.java
@@ -39,4 +39,8 @@ public interface PostRepository {
 
     // 게시글 ID 목록을 통해 게시글을 조회한다.
     List<PostWithScrapAndImageDTO> findByIdIn(final List<Long> postIds, final long userId);
+
+    List<Post> findAllByAuthorId(final long authorId);
+
+    void deleteAllByAuthorId(final long authorId);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/PostScrapRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/PostScrapRepository.java
@@ -21,4 +21,6 @@ public interface PostScrapRepository {
     void deleteAllByPostId(final long postId);
 
     void deleteAllByPostIdIn(final List<Long> postIds);
+
+    void deleteAllByUserId(final long userId);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/PostScrapRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/PostScrapRepository.java
@@ -19,4 +19,6 @@ public interface PostScrapRepository {
     List<PostWithScrapAndImageDTO> findPostsScrappedByUser(final long userId);
 
     void deleteAllByPostId(final long postId);
+
+    void deleteAllByPostIdIn(final List<Long> postIds);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/impl/post/CommentLikeRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/impl/post/CommentLikeRepositoryImpl.java
@@ -66,4 +66,9 @@ public class CommentLikeRepositoryImpl implements CommentLikeRepository {
     public void deleteAllByPostIdIn(final List<Long> postIds) {
         commentLikeJpaRepository.deleteAllByPostIdIn(postIds);
     }
+
+    @Override
+    public void deleteAllByUserId(final long userId) {
+        commentLikeJpaRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/com/ripple/BE/post/persistence/impl/post/CommentLikeRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/impl/post/CommentLikeRepositoryImpl.java
@@ -61,4 +61,9 @@ public class CommentLikeRepositoryImpl implements CommentLikeRepository {
     public List<LikeCommentWithPostDTO> findLikedCommentsByUserIdWithPost(long userId) {
         return commentLikeJpaRepository.findLikedCommentsByUserIdWithPost(userId);
     }
+
+    @Override
+    public void deleteAllByPostIdIn(final List<Long> postIds) {
+        commentLikeJpaRepository.deleteAllByPostIdIn(postIds);
+    }
 }

--- a/src/main/java/com/ripple/BE/post/persistence/impl/post/CommentLikeRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/impl/post/CommentLikeRepositoryImpl.java
@@ -63,8 +63,8 @@ public class CommentLikeRepositoryImpl implements CommentLikeRepository {
     }
 
     @Override
-    public void deleteAllByPostIdIn(final List<Long> postIds) {
-        commentLikeJpaRepository.deleteAllByPostIdIn(postIds);
+    public void deleteAllByCommentIdIn(final List<Long> commentIds) {
+        commentLikeJpaRepository.deleteAllByCommentIdIn(commentIds);
     }
 
     @Override

--- a/src/main/java/com/ripple/BE/post/persistence/impl/post/CommentRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/impl/post/CommentRepositoryImpl.java
@@ -58,4 +58,11 @@ public class CommentRepositoryImpl implements CommentRepository {
     public void deleteAllByPostIdIn(final List<Long> postIds) {
         commentJpaRepository.deleteAllByPostIdIn(postIds);
     }
+
+    @Override
+    public List<Comment> findAllByPostIdIn(final List<Long> postIds) {
+        return commentJpaRepository.findAllByPostIdIn(postIds).stream()
+                .map(CommentJpaEntity::toModel)
+                .toList();
+    }
 }

--- a/src/main/java/com/ripple/BE/post/persistence/impl/post/CommentRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/impl/post/CommentRepositoryImpl.java
@@ -53,4 +53,9 @@ public class CommentRepositoryImpl implements CommentRepository {
     public List<CommentWithPostDTO> findUserCommentsWithPost(final long userId) {
         return commentJpaRepository.findUserCommentsWithPost(userId);
     }
+
+    @Override
+    public void deleteAllByPostIdIn(final List<Long> postIds) {
+        commentJpaRepository.deleteAllByPostIdIn(postIds);
+    }
 }

--- a/src/main/java/com/ripple/BE/post/persistence/impl/post/PostLikeRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/impl/post/PostLikeRepositoryImpl.java
@@ -52,4 +52,9 @@ public class PostLikeRepositoryImpl implements PostLikeRepository {
     public void deleteAllByPostIdIn(final List<Long> postIds) {
         postLikeJpaRepository.deleteAllByPostIdIn(postIds);
     }
+
+    @Override
+    public void deleteAllByUserId(final long userId) {
+        postLikeJpaRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/com/ripple/BE/post/persistence/impl/post/PostLikeRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/impl/post/PostLikeRepositoryImpl.java
@@ -47,4 +47,9 @@ public class PostLikeRepositoryImpl implements PostLikeRepository {
     public void deleteAllByPostId(final long postId) {
         postLikeJpaRepository.deleteAllByPostId(postId);
     }
+
+    @Override
+    public void deleteAllByPostIdIn(final List<Long> postIds) {
+        postLikeJpaRepository.deleteAllByPostIdIn(postIds);
+    }
 }

--- a/src/main/java/com/ripple/BE/post/persistence/impl/post/PostRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/impl/post/PostRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.ripple.BE.post.persistence.jpa.entity.PostJpaEntity;
 import com.ripple.BE.post.persistence.jpa.repository.post.PostJpaRepository;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -72,5 +73,17 @@ public class PostRepositoryImpl implements PostRepository {
     @Override
     public List<PostWithScrapAndImageDTO> findByIdIn(final List<Long> postIds, final long userId) {
         return postJpaRepository.findByIdIn(postIds, userId);
+    }
+
+    @Override
+    public List<Post> findAllByAuthorId(final long authorId) {
+        return postJpaRepository.findAllByAuthorId(authorId).stream()
+                .map(PostJpaEntity::toModel)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void deleteAllByAuthorId(final long authorId) {
+        postJpaRepository.deleteAllByAuthorId(authorId);
     }
 }

--- a/src/main/java/com/ripple/BE/post/persistence/impl/post/PostScrapRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/impl/post/PostScrapRepositoryImpl.java
@@ -52,4 +52,9 @@ public class PostScrapRepositoryImpl implements PostScrapRepository {
     public void deleteAllByPostIdIn(final List<Long> postIds) {
         postScrapJpaRepository.deleteAllByPostIdIn(postIds);
     }
+
+    @Override
+    public void deleteAllByUserId(final long userId) {
+        postScrapJpaRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/com/ripple/BE/post/persistence/impl/post/PostScrapRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/impl/post/PostScrapRepositoryImpl.java
@@ -47,4 +47,9 @@ public class PostScrapRepositoryImpl implements PostScrapRepository {
     public void deleteAllByPostId(final long postId) {
         postScrapJpaRepository.deleteAllByPostId(postId);
     }
+
+    @Override
+    public void deleteAllByPostIdIn(final List<Long> postIds) {
+        postScrapJpaRepository.deleteAllByPostIdIn(postIds);
+    }
 }

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/comment/CommentJpaRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/comment/CommentJpaRepository.java
@@ -18,4 +18,6 @@ public interface CommentJpaRepository
     List<CommentJpaEntity> findAllByCommenterId(Long userId);
 
     void deleteAllByPostId(Long postId);
+
+    void deleteAllByPostIdIn(List<Long> postIds);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/comment/CommentJpaRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/comment/CommentJpaRepository.java
@@ -20,4 +20,6 @@ public interface CommentJpaRepository
     void deleteAllByPostId(Long postId);
 
     void deleteAllByPostIdIn(List<Long> postIds);
+
+    List<CommentJpaEntity> findAllByPostIdIn(List<Long> postIds);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/commentlike/CommentLikeJpaRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/commentlike/CommentLikeJpaRepository.java
@@ -33,4 +33,6 @@ public interface CommentLikeJpaRepository
 	List<CommentLikeJpaEntity> findByUserIdAndCommentIdIn(long userId, Set<Long> commentIds);
 
 	void deleteAllByPostIdIn(List<Long> postIds);
+
+	void deleteAllByUserId(long userId);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/commentlike/CommentLikeJpaRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/commentlike/CommentLikeJpaRepository.java
@@ -31,4 +31,6 @@ public interface CommentLikeJpaRepository
 	void deleteAllByPostId(@Param("postId") Long postId);
 
 	List<CommentLikeJpaEntity> findByUserIdAndCommentIdIn(long userId, Set<Long> commentIds);
+
+	void deleteAllByPostIdIn(List<Long> postIds);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/commentlike/CommentLikeJpaRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/commentlike/CommentLikeJpaRepository.java
@@ -32,7 +32,7 @@ public interface CommentLikeJpaRepository
 
 	List<CommentLikeJpaEntity> findByUserIdAndCommentIdIn(long userId, Set<Long> commentIds);
 
-	void deleteAllByPostIdIn(List<Long> postIds);
+	void deleteAllByCommentIdIn(List<Long> commentIds);
 
 	void deleteAllByUserId(long userId);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/post/PostJpaRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/post/PostJpaRepository.java
@@ -2,6 +2,7 @@ package com.ripple.BE.post.persistence.jpa.repository.post;
 
 import com.ripple.BE.post.persistence.jpa.entity.PostJpaEntity;
 import jakarta.persistence.LockModeType;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -13,4 +14,8 @@ public interface PostJpaRepository
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM PostJpaEntity p WHERE p.id = :id")
     Optional<PostJpaEntity> findByIdForUpdate(long id);
+
+    List<PostJpaEntity> findAllByAuthorId(long authorId);
+
+    void deleteAllByAuthorId(long authorId);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/postlike/PostLikeJpaRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/postlike/PostLikeJpaRepository.java
@@ -1,6 +1,7 @@
 package com.ripple.BE.post.persistence.jpa.repository.postlike;
 
 import com.ripple.BE.post.persistence.jpa.entity.PostLikeJpaEntity;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -14,4 +15,6 @@ public interface PostLikeJpaRepository
     boolean existsByPostIdAndUserId(long postId, long userId);
 
     void deleteAllByPostId(long postId);
+
+    void deleteAllByPostIdIn(List<Long> postIds);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/postlike/PostLikeJpaRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/postlike/PostLikeJpaRepository.java
@@ -17,4 +17,6 @@ public interface PostLikeJpaRepository
     void deleteAllByPostId(long postId);
 
     void deleteAllByPostIdIn(List<Long> postIds);
+
+    void deleteAllByUserId(long userId);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/postscrap/PostScrapJpaRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/postscrap/PostScrapJpaRepository.java
@@ -1,6 +1,7 @@
 package com.ripple.BE.post.persistence.jpa.repository.postscrap;
 
 import com.ripple.BE.post.persistence.jpa.entity.PostScrapJpaEntity;
+import java.util.Collection;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,4 +13,6 @@ public interface PostScrapJpaRepository
     boolean existsByPostIdAndUserId(long postId, long userId);
 
     void deleteAllByPostId(long postId);
+
+    void deleteAllByPostIdIn(Collection<Long> postId);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/postscrap/PostScrapJpaRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/postscrap/PostScrapJpaRepository.java
@@ -15,4 +15,6 @@ public interface PostScrapJpaRepository
     void deleteAllByPostId(long postId);
 
     void deleteAllByPostIdIn(Collection<Long> postId);
+
+    void deleteAllByUserId(long userId);
 }

--- a/src/main/java/com/ripple/BE/term/persistence/TermScrapRepository.java
+++ b/src/main/java/com/ripple/BE/term/persistence/TermScrapRepository.java
@@ -18,4 +18,6 @@ public interface TermScrapRepository {
     List<TermWithScrapDTO> findTermsScrappedByUserAndInitial(long userId, String initial);
 
     List<TermWithScrapDTO> findTermsScrappedByUserAndKeyword(long userId, String keyword);
+
+    void deleteAllByUserId(long userId);
 }

--- a/src/main/java/com/ripple/BE/term/persistence/impl/TermScrapRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/term/persistence/impl/TermScrapRepositoryImpl.java
@@ -48,4 +48,9 @@ public class TermScrapRepositoryImpl implements TermScrapRepository {
     public List<TermWithScrapDTO> findTermsScrappedByUserAndKeyword(long userId, String keyword) {
         return termScrapJpaRepository.findTermsScrappedByUserAndKeyword(userId, keyword);
     }
+
+    @Override
+    public void deleteAllByUserId(final long userId) {
+        termScrapJpaRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/com/ripple/BE/term/persistence/jpa/repository/termscrap/TermScrapJpaRepository.java
+++ b/src/main/java/com/ripple/BE/term/persistence/jpa/repository/termscrap/TermScrapJpaRepository.java
@@ -10,4 +10,6 @@ public interface TermScrapJpaRepository
     Optional<TermScrapJpaEntity> findByTermIdAndUserId(long termId, long userId);
 
     boolean existsByTermIdAndUserId(long termId, long userId);
+
+    void deleteAllByUserId(long userId);
 }

--- a/src/main/java/com/ripple/BE/user/controller/UserController.java
+++ b/src/main/java/com/ripple/BE/user/controller/UserController.java
@@ -256,13 +256,12 @@ public class UserController {
             description =
                 """
                 - 로그인한 유저를 탈퇴시킵니다.
-                - 탈퇴 시 30일 간 유저의 정보가 유지되며, 이후에는 복구가 불가능합니다.
-                
+                - 유저의 모든 데이터는 삭제되며, 복구할 수 없습니다.
                 """
     )
     @DeleteMapping()
     public ResponseEntity<ApiResponse<?>> deleteUser(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        userService.softDeleteUser(customUserDetails.getId());
+        userService.deleteUser(customUserDetails.getId());
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
     }
 }

--- a/src/main/java/com/ripple/BE/user/controller/UserController.java
+++ b/src/main/java/com/ripple/BE/user/controller/UserController.java
@@ -250,4 +250,19 @@ public class UserController {
 
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(myToktok));
     }
+
+    @Operation(
+            summary = "유저 탈퇴",
+            description =
+                """
+                - 로그인한 유저를 탈퇴시킵니다.
+                - 탈퇴 시 30일 간 유저의 정보가 유지되며, 이후에는 복구가 불가능합니다.
+                
+                """
+    )
+    @DeleteMapping()
+    public ResponseEntity<ApiResponse<?>> deleteUser(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        userService.softDeleteUser(customUserDetails.getId());
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
+    }
 }

--- a/src/main/java/com/ripple/BE/user/domain/User.java
+++ b/src/main/java/com/ripple/BE/user/domain/User.java
@@ -118,9 +118,6 @@ public class User extends BaseJpaEntity {
     @Column(name = "beginner_completed_count", nullable = false, columnDefinition = "INT DEFAULT 0")
     private int beginnerCompletedCount;
 
-    @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted = false;
-
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
@@ -217,10 +214,5 @@ public class User extends BaseJpaEntity {
 
     public void updateLevelTestCompleted(boolean isLevelTestCompleted) {
         this.isLevelTestCompleted = isLevelTestCompleted;
-    }
-
-    public void softDelete() {
-        this.isDeleted = true;
-        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/ripple/BE/user/domain/User.java
+++ b/src/main/java/com/ripple/BE/user/domain/User.java
@@ -22,6 +22,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
 import java.util.Date;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -117,6 +118,12 @@ public class User extends BaseJpaEntity {
     @Column(name = "beginner_completed_count", nullable = false, columnDefinition = "INT DEFAULT 0")
     private int beginnerCompletedCount;
 
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @Column(
             name = "intermediate_completed_count",
             nullable = false,
@@ -210,5 +217,10 @@ public class User extends BaseJpaEntity {
 
     public void updateLevelTestCompleted(boolean isLevelTestCompleted) {
         this.isLevelTestCompleted = isLevelTestCompleted;
+    }
+
+    public void softDelete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/ripple/BE/user/domain/User.java
+++ b/src/main/java/com/ripple/BE/user/domain/User.java
@@ -22,7 +22,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
-import java.time.LocalDateTime;
 import java.util.Date;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -117,9 +116,6 @@ public class User extends BaseJpaEntity {
 
     @Column(name = "beginner_completed_count", nullable = false, columnDefinition = "INT DEFAULT 0")
     private int beginnerCompletedCount;
-
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
 
     @Column(
             name = "intermediate_completed_count",

--- a/src/main/java/com/ripple/BE/user/exception/errorcode/UserErrorCode.java
+++ b/src/main/java/com/ripple/BE/user/exception/errorcode/UserErrorCode.java
@@ -17,7 +17,8 @@ public enum UserErrorCode implements ErrorCode {
     USER_GOAL_NOT_FOUND(HttpStatus.NOT_FOUND, "User Goal not found"),
     DUPLICATED_NICKNAME(
             HttpStatus.BAD_REQUEST, "Duplicated Nickname is already exist. Please use another nickname"),
-    ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Attendance not found");
+    ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Attendance not found"),
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "User already deleted");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/ripple/BE/user/repository/AttendanceLogRepository.java
+++ b/src/main/java/com/ripple/BE/user/repository/AttendanceLogRepository.java
@@ -13,4 +13,6 @@ public interface AttendanceLogRepository extends JpaRepository<AttendanceLog, Lo
     Optional<AttendanceLog> findByAttendanceIdAndDate(Long attendanceId, LocalDate date);
 
     List<AttendanceLog> findByAttendanceId(Long attendanceId);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/ripple/BE/user/repository/AttendanceLogRepository.java
+++ b/src/main/java/com/ripple/BE/user/repository/AttendanceLogRepository.java
@@ -1,5 +1,6 @@
 package com.ripple.BE.user.repository;
 
+import com.ripple.BE.user.domain.Attendance;
 import com.ripple.BE.user.domain.AttendanceLog;
 import java.time.LocalDate;
 import java.util.List;
@@ -14,5 +15,5 @@ public interface AttendanceLogRepository extends JpaRepository<AttendanceLog, Lo
 
     List<AttendanceLog> findByAttendanceId(Long attendanceId);
 
-    void deleteAllByUserId(Long userId);
+    void deleteAllByAttendance(Attendance attendance);
 }

--- a/src/main/java/com/ripple/BE/user/repository/AttendanceLogRepository.java
+++ b/src/main/java/com/ripple/BE/user/repository/AttendanceLogRepository.java
@@ -14,5 +14,5 @@ public interface AttendanceLogRepository extends JpaRepository<AttendanceLog, Lo
 
     List<AttendanceLog> findByAttendanceId(Long attendanceId);
 
-    void deleteByUserId(Long userId);
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/ripple/BE/user/repository/AttendanceRepository.java
+++ b/src/main/java/com/ripple/BE/user/repository/AttendanceRepository.java
@@ -9,5 +9,5 @@ import org.springframework.stereotype.Repository;
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
     Optional<Attendance> findByUserId(Long userId);
 
-    void deleteByUserId(Long userId);
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/ripple/BE/user/repository/AttendanceRepository.java
+++ b/src/main/java/com/ripple/BE/user/repository/AttendanceRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
     Optional<Attendance> findByUserId(Long userId);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/ripple/BE/user/repository/QuestRepository.java
+++ b/src/main/java/com/ripple/BE/user/repository/QuestRepository.java
@@ -12,4 +12,6 @@ public interface QuestRepository extends JpaRepository<Quest, Long> {
     Optional<Quest> findByUserId(Long userId);
 
     List<Quest> findAll();
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/ripple/BE/user/repository/QuestRepository.java
+++ b/src/main/java/com/ripple/BE/user/repository/QuestRepository.java
@@ -13,5 +13,5 @@ public interface QuestRepository extends JpaRepository<Quest, Long> {
 
     List<Quest> findAll();
 
-    void deleteByUserId(Long userId);
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/ripple/BE/user/repository/UserGoalRepository.java
+++ b/src/main/java/com/ripple/BE/user/repository/UserGoalRepository.java
@@ -9,5 +9,5 @@ import org.springframework.stereotype.Repository;
 public interface UserGoalRepository extends JpaRepository<UserGoal, Long> {
     Optional<UserGoal> findByUserId(Long userId);
 
-    void deleteByUserId(Long userId);
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/ripple/BE/user/repository/UserGoalRepository.java
+++ b/src/main/java/com/ripple/BE/user/repository/UserGoalRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserGoalRepository extends JpaRepository<UserGoal, Long> {
     Optional<UserGoal> findByUserId(Long userId);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/ripple/BE/user/repository/UserRepository.java
+++ b/src/main/java/com/ripple/BE/user/repository/UserRepository.java
@@ -49,4 +49,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	@Modifying
 	@Query("UPDATE User u SET u.currentLevel = :newLevel WHERE u.id = :userId")
 	void updateLevel(@Param("userId") Long userId, @Param("newLevel") String newLevel);
+
+	void deleteById(Long id);
 }

--- a/src/main/java/com/ripple/BE/user/service/UserService.java
+++ b/src/main/java/com/ripple/BE/user/service/UserService.java
@@ -22,6 +22,7 @@ import com.ripple.BE.post.persistence.CommentRepository;
 import com.ripple.BE.post.persistence.PostLikeRepository;
 import com.ripple.BE.post.persistence.PostScrapRepository;
 import com.ripple.BE.term.persistence.TermScrapRepository;
+import com.ripple.BE.user.domain.Attendance;
 import com.ripple.BE.user.domain.User;
 import com.ripple.BE.user.domain.UserGoal;
 import com.ripple.BE.user.domain.type.LoginType;
@@ -260,27 +261,8 @@ public class UserService {
     public void deleteUser(final long userId) {
         User user = findUserById(userId);
 
+        // 챗봇 대화 기록 삭제
         chatbotRepository.deleteAllByUserId(userId);
-
-        // 학습 관련 데이터 삭제
-        conceptScrapRepository.deleteAllByUserId(userId);
-        userLearningSetRepository.deleteAllByUserId(userId);
-        quizScrapRepository.deleteAllByUserId(userId);
-        failQuizRepository.deleteAllByUserId(userId);
-        newsScrapRepository.deleteAllByUserId(userId);
-        termScrapRepository.deleteAllByUserId(userId);
-
-        // 출석 관련 데이터 삭제
-        attendanceLogRepository.deleteAllByUserId(userId);
-        attendanceRepository.deleteAllByUserId(userId);
-
-        // 유저 관련 데이터 삭제
-        userGoalRepository.deleteAllByUserId(userId);
-        questRepository.deleteAllByUserId(userId);
-        notificationRepository.deleteAllByUserId(userId);
-        if (user.getProfileImage() != null) {
-            imageRepository.deleteById(user.getProfileImage().getId());
-        }
 
         // 게시글 관련 데이터 삭제
         commentLikeRepository.deleteAllByUserId(userId);
@@ -291,6 +273,30 @@ public class UserService {
             commentCommandService.removeCommentFromPost(userId, comment.getPostId(), comment.getId());
         }
         postCommandService.deleteAllPostsByUserId(userId);
+
+        // 학습 관련 데이터 삭제
+        conceptScrapRepository.deleteAllByUserId(userId);
+        userLearningSetRepository.deleteAllByUserId(userId);
+        quizScrapRepository.deleteAllByUserId(userId);
+        failQuizRepository.deleteAllByUserId(userId);
+        newsScrapRepository.deleteAllByUserId(userId);
+        termScrapRepository.deleteAllByUserId(userId);
+
+        // 출석 관련 데이터 삭제
+        Attendance attendance =
+                attendanceRepository
+                        .findByUserId(userId)
+                        .orElseThrow(() -> new UserException(ATTENDANCE_NOT_FOUND));
+        attendanceLogRepository.deleteAllByAttendance(attendance);
+        attendanceRepository.deleteAllByUserId(userId);
+
+        // 유저 관련 데이터 삭제
+        userGoalRepository.deleteAllByUserId(userId);
+        questRepository.deleteAllByUserId(userId);
+        notificationRepository.deleteAllByReceiverId(userId);
+        if (user.getProfileImage() != null) {
+            imageRepository.deleteById(user.getProfileImage().getId());
+        }
 
         // 유저 삭제
         userRepository.delete(user);

--- a/src/main/java/com/ripple/BE/user/service/UserService.java
+++ b/src/main/java/com/ripple/BE/user/service/UserService.java
@@ -4,9 +4,14 @@ import static com.ripple.BE.user.domain.User.*;
 import static com.ripple.BE.user.exception.errorcode.UserErrorCode.*;
 
 import com.ripple.BE.auth.dto.kakao.KakaoUserInfoResponse;
+import com.ripple.BE.chatbot.repository.ChatbotRepository;
 import com.ripple.BE.image.domain.Image;
 import com.ripple.BE.image.persistence.ImageRepository;
 import com.ripple.BE.image.persistence.jpa.entity.ImageJpaEntity;
+import com.ripple.BE.learning.persistence.ConceptScrapRepository;
+import com.ripple.BE.learning.persistence.FailQuizRepository;
+import com.ripple.BE.learning.persistence.QuizScrapRepository;
+import com.ripple.BE.learning.persistence.UserLearningSetRepository;
 import com.ripple.BE.user.domain.User;
 import com.ripple.BE.user.domain.UserGoal;
 import com.ripple.BE.user.domain.type.LoginType;
@@ -41,6 +46,12 @@ public class UserService {
     private final AttendanceLogRepository attendanceLogRepository;
     private final AttendanceRepository attendanceRepository;
     private final QuestRepository questRepository;
+    private final ChatbotRepository chatbotRepository;
+
+    private final ConceptScrapRepository conceptScrapRepository;
+    private final UserLearningSetRepository userLearningSetRepository;
+    private final QuizScrapRepository quizScrapRepository;
+    private final FailQuizRepository failQuizRepository;
 
     private final AttendanceService attendanceService;
 
@@ -228,11 +239,21 @@ public class UserService {
     public void deleteUser(final long userId) {
         User user = findUserById(userId);
 
+        chatbotRepository.deleteAllByUserId(userId);
+
+        // 학습 데이터 관련 삭제
+        conceptScrapRepository.deleteAllByUserId(userId);
+        userLearningSetRepository.deleteAllByUserId(userId);
+        quizScrapRepository.deleteAllByUserId(userId);
+        failQuizRepository.deleteAllByUserId(userId);
+
+        // 출석 관련 데이터 삭제
+        attendanceLogRepository.deleteAllByUserId(userId);
+        attendanceRepository.deleteAllByUserId(userId);
+
         // 유저 관련 데이터 삭제
-        questRepository.deleteByUserId(userId);
-        attendanceLogRepository.deleteByUserId(userId);
-        attendanceRepository.deleteByUserId(userId);
-        userGoalRepository.deleteByUserId(userId);
+        userGoalRepository.deleteAllByUserId(userId);
+        questRepository.deleteAllByUserId(userId);
         if (user.getProfileImage() != null) {
             imageRepository.deleteById(user.getProfileImage().getId());
         }

--- a/src/main/java/com/ripple/BE/user/service/UserService.java
+++ b/src/main/java/com/ripple/BE/user/service/UserService.java
@@ -16,6 +16,9 @@ import com.ripple.BE.user.dto.request.PatchUserProfileRequest;
 import com.ripple.BE.user.dto.request.UpdateUserProfileRequest;
 import com.ripple.BE.user.dto.request.UserGoalRequest;
 import com.ripple.BE.user.exception.UserException;
+import com.ripple.BE.user.repository.AttendanceLogRepository;
+import com.ripple.BE.user.repository.AttendanceRepository;
+import com.ripple.BE.user.repository.QuestRepository;
 import com.ripple.BE.user.repository.UserGoalRepository;
 import com.ripple.BE.user.repository.UserRepository;
 import java.util.Date;
@@ -34,9 +37,13 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final ImageRepository imageRepository;
+    private final UserGoalRepository userGoalRepository;
+    private final AttendanceLogRepository attendanceLogRepository;
+    private final AttendanceRepository attendanceRepository;
+    private final QuestRepository questRepository;
+
     private final AttendanceService attendanceService;
 
-    private final UserGoalRepository userGoalRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
@@ -218,12 +225,19 @@ public class UserService {
         }
     }
 
-    public void softDeleteUser(final long userId) {
+    public void deleteUser(final long userId) {
         User user = findUserById(userId);
-        if (user.isDeleted()) {
-            throw new UserException(USER_ALREADY_DELETED);
+
+        // 유저 관련 데이터 삭제
+        questRepository.deleteByUserId(userId);
+        attendanceLogRepository.deleteByUserId(userId);
+        attendanceRepository.deleteByUserId(userId);
+        userGoalRepository.deleteByUserId(userId);
+        if (user.getProfileImage() != null) {
+            imageRepository.deleteById(user.getProfileImage().getId());
         }
-        user.softDelete();
-        userRepository.save(user);
+
+        // 유저 삭제
+        userRepository.delete(user);
     }
 }

--- a/src/main/java/com/ripple/BE/user/service/UserService.java
+++ b/src/main/java/com/ripple/BE/user/service/UserService.java
@@ -14,6 +14,13 @@ import com.ripple.BE.learning.persistence.QuizScrapRepository;
 import com.ripple.BE.learning.persistence.UserLearningSetRepository;
 import com.ripple.BE.news.persistence.NewsScrapRepository;
 import com.ripple.BE.notification.persistence.NotificationRepository;
+import com.ripple.BE.post.application.impl.common.CommentCommandService;
+import com.ripple.BE.post.application.impl.post.PostCommandService;
+import com.ripple.BE.post.domain.comment.Comment;
+import com.ripple.BE.post.persistence.CommentLikeRepository;
+import com.ripple.BE.post.persistence.CommentRepository;
+import com.ripple.BE.post.persistence.PostLikeRepository;
+import com.ripple.BE.post.persistence.PostScrapRepository;
 import com.ripple.BE.term.persistence.TermScrapRepository;
 import com.ripple.BE.user.domain.User;
 import com.ripple.BE.user.domain.UserGoal;
@@ -30,6 +37,7 @@ import com.ripple.BE.user.repository.QuestRepository;
 import com.ripple.BE.user.repository.UserGoalRepository;
 import com.ripple.BE.user.repository.UserRepository;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -58,8 +66,15 @@ public class UserService {
     private final UserLearningSetRepository userLearningSetRepository;
     private final QuizScrapRepository quizScrapRepository;
     private final FailQuizRepository failQuizRepository;
+    private final CommentRepository commentRepository;
+
+    private final PostLikeRepository postLikeRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final PostScrapRepository postScrapRepository;
 
     private final AttendanceService attendanceService;
+    private final PostCommandService postCommandService;
+    private final CommentCommandService commentCommandService;
 
     private final PasswordEncoder passwordEncoder;
 
@@ -266,6 +281,16 @@ public class UserService {
         if (user.getProfileImage() != null) {
             imageRepository.deleteById(user.getProfileImage().getId());
         }
+
+        // 게시글 관련 데이터 삭제
+        commentLikeRepository.deleteAllByUserId(userId);
+        postLikeRepository.deleteAllByUserId(userId);
+        postScrapRepository.deleteAllByUserId(userId);
+        List<Comment> comments = commentRepository.findAllByCommenterId(userId);
+        for (Comment comment : comments) {
+            commentCommandService.removeCommentFromPost(userId, comment.getPostId(), comment.getId());
+        }
+        postCommandService.deleteAllPostsByUserId(userId);
 
         // 유저 삭제
         userRepository.delete(user);

--- a/src/main/java/com/ripple/BE/user/service/UserService.java
+++ b/src/main/java/com/ripple/BE/user/service/UserService.java
@@ -217,4 +217,13 @@ public class UserService {
             user.updateProfileImage(ImageJpaEntity.from(image)); // 추후 수정 필요
         }
     }
+
+    public void softDeleteUser(final long userId) {
+        User user = findUserById(userId);
+        if (user.isDeleted()) {
+            throw new UserException(USER_ALREADY_DELETED);
+        }
+        user.softDelete();
+        userRepository.save(user);
+    }
 }

--- a/src/main/java/com/ripple/BE/user/service/UserService.java
+++ b/src/main/java/com/ripple/BE/user/service/UserService.java
@@ -12,6 +12,9 @@ import com.ripple.BE.learning.persistence.ConceptScrapRepository;
 import com.ripple.BE.learning.persistence.FailQuizRepository;
 import com.ripple.BE.learning.persistence.QuizScrapRepository;
 import com.ripple.BE.learning.persistence.UserLearningSetRepository;
+import com.ripple.BE.news.persistence.NewsScrapRepository;
+import com.ripple.BE.notification.persistence.NotificationRepository;
+import com.ripple.BE.term.persistence.TermScrapRepository;
 import com.ripple.BE.user.domain.User;
 import com.ripple.BE.user.domain.UserGoal;
 import com.ripple.BE.user.domain.type.LoginType;
@@ -47,6 +50,9 @@ public class UserService {
     private final AttendanceRepository attendanceRepository;
     private final QuestRepository questRepository;
     private final ChatbotRepository chatbotRepository;
+    private final NotificationRepository notificationRepository;
+    private final NewsScrapRepository newsScrapRepository;
+    private final TermScrapRepository termScrapRepository;
 
     private final ConceptScrapRepository conceptScrapRepository;
     private final UserLearningSetRepository userLearningSetRepository;
@@ -241,11 +247,13 @@ public class UserService {
 
         chatbotRepository.deleteAllByUserId(userId);
 
-        // 학습 데이터 관련 삭제
+        // 학습 관련 데이터 삭제
         conceptScrapRepository.deleteAllByUserId(userId);
         userLearningSetRepository.deleteAllByUserId(userId);
         quizScrapRepository.deleteAllByUserId(userId);
         failQuizRepository.deleteAllByUserId(userId);
+        newsScrapRepository.deleteAllByUserId(userId);
+        termScrapRepository.deleteAllByUserId(userId);
 
         // 출석 관련 데이터 삭제
         attendanceLogRepository.deleteAllByUserId(userId);
@@ -254,6 +262,7 @@ public class UserService {
         // 유저 관련 데이터 삭제
         userGoalRepository.deleteAllByUserId(userId);
         questRepository.deleteAllByUserId(userId);
+        notificationRepository.deleteAllByUserId(userId);
         if (user.getProfileImage() != null) {
             imageRepository.deleteById(user.getProfileImage().getId());
         }

--- a/src/main/java/com/ripple/BE/user/service/UserService.java
+++ b/src/main/java/com/ripple/BE/user/service/UserService.java
@@ -258,6 +258,7 @@ public class UserService {
         }
     }
 
+    @Transactional
     public void deleteUser(final long userId) {
         User user = findUserById(userId);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #107 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 회원 삭제 시 관련된 모든 테이블 삭제하도록 구현하였습니다
- 챗봇 > 게시물 관련 > 학습 > 출석 > 유저관련 > 유저 순으로 삭제했습니다
- Post 삭제시에는 In 쿼리를 이용하였고 Comment는 기존 메서드 재활용하는 방향으로 구현했습니다. 
- 추가적으로 로그인에서 get 매핑으로 되어있는 부분들 post로 변경했습니다


## 💬리뷰 요구사항(선택)

>  user 패키지 쪽도 찬민님 하신 것 처럼 리팩토링을 하려고했는데,,,,너무 많아서 차마 못건드렸습니다....!! 🥹
> cascade가 없다보니 코드가 좀 복잡해지긴했는데 로컬 테스트 결과로는 정상적으로 탈퇴되는 것 확인했습니다.