### PR TITLE
[Refactor] 경제톡톡 게시물, 게시물 QueryProjection 추가 및 기타 수정

### DIFF
--- a/src/main/java/com/ripple/BE/post/application/impl/post/PostQueryService.java
+++ b/src/main/java/com/ripple/BE/post/application/impl/post/PostQueryService.java
@@ -1,7 +1,6 @@
 package com.ripple.BE.post.application.impl.post;
 
 import static com.ripple.BE.post.exception.errorcode.PostErrorCode.*;
-import static com.ripple.BE.user.exception.errorcode.UserErrorCode.*;
 
 import com.ripple.BE.image.dto.response.ImageResponse;
 import com.ripple.BE.image.persistence.ImageRepository;
@@ -9,7 +8,6 @@ import com.ripple.BE.post.application.CommentQueryUseCase;
 import com.ripple.BE.post.application.PostQueryUseCase;
 import com.ripple.BE.post.application.cache.PostCacheKey;
 import com.ripple.BE.post.application.cache.PostCacheManager;
-import com.ripple.BE.post.domain.post.Post;
 import com.ripple.BE.post.domain.type.PostSort;
 import com.ripple.BE.post.domain.type.PostType;
 import com.ripple.BE.post.dto.response.CommentResponseDTO;
@@ -17,13 +15,10 @@ import com.ripple.BE.post.dto.response.PostPreviewListResponseDTO;
 import com.ripple.BE.post.dto.response.PostPreviewResponseDTO;
 import com.ripple.BE.post.dto.response.PostResponseDTO;
 import com.ripple.BE.post.exception.PostException;
-import com.ripple.BE.post.persistence.PostLikeRepository;
 import com.ripple.BE.post.persistence.PostRepository;
-import com.ripple.BE.post.persistence.PostScrapRepository;
+import com.ripple.BE.post.persistence.dto.PostDetailDTO;
 import com.ripple.BE.post.persistence.dto.PostWithImageDTO;
 import com.ripple.BE.search.service.SearchService;
-import com.ripple.BE.user.domain.User;
-import com.ripple.BE.user.repository.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -38,9 +33,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostQueryService implements PostQueryUseCase {
 
     private final PostRepository postRepository;
-    private final PostLikeRepository postLikeRepository;
-    private final PostScrapRepository postScrapRepository;
-    private final UserRepository userRepository;
     private final ImageRepository imageRepository;
 
     private final CommentQueryUseCase commentQueryUseCase;
@@ -101,23 +93,20 @@ public class PostQueryService implements PostQueryUseCase {
 
     @Override
     public PostResponseDTO getPost(final long postId, final long userId) {
-        Post post =
-                postRepository.findById(postId).orElseThrow(() -> new PostException(POST_NOT_FOUND));
-        User author =
-                userRepository
-                        .findById(post.getAuthorId())
-                        .orElseThrow(() -> new PostException(USER_NOT_FOUND));
+        // 1. 게시물 정보 조회, (스크랩, 좋아요, 사용자) 여부 조회
+        PostDetailDTO dto =
+                postRepository
+                        .findPostDetail(postId, userId)
+                        .orElseThrow(() -> new PostException(POST_NOT_FOUND));
 
-        boolean isAuthor = post.isOwnedBy(userId);
-        boolean isLiked = postLikeRepository.existsByPostIdAndUserId(postId, userId);
-        boolean isScrapped = postScrapRepository.existsByPostIdAndUserId(postId, userId);
-
+        // 2. 이미지 정보 조회
         List<ImageResponse> imageResponses =
                 imageRepository.findByPostId(postId).stream().map(ImageResponse::from).toList();
+
+        // 3. 댓글 정보 조회
         List<CommentResponseDTO> commentDTOs = commentQueryUseCase.getComments(postId, userId);
 
-        return PostResponseDTO.of(
-                post, author, imageResponses, commentDTOs, isScrapped, isLiked, isAuthor);
+        return PostResponseDTO.of(dto, imageResponses, commentDTOs);
     }
 
     public PostPreviewListResponseDTO searchPosts(

--- a/src/main/java/com/ripple/BE/post/application/impl/toktok/ToktokQueryService.java
+++ b/src/main/java/com/ripple/BE/post/application/impl/toktok/ToktokQueryService.java
@@ -8,16 +8,14 @@ import com.ripple.BE.post.application.CommentQueryUseCase;
 import com.ripple.BE.post.application.ToktokQueryUseCase;
 import com.ripple.BE.post.application.cache.PostCacheKey;
 import com.ripple.BE.post.application.cache.PostCacheManager;
-import com.ripple.BE.post.domain.post.Post;
 import com.ripple.BE.post.domain.type.PostSort;
 import com.ripple.BE.post.dto.response.CommentResponseDTO;
 import com.ripple.BE.post.dto.response.ToktokPreviewListResponseDTO;
 import com.ripple.BE.post.dto.response.ToktokPreviewResponseDTO;
 import com.ripple.BE.post.dto.response.ToktokResponseDTO;
 import com.ripple.BE.post.exception.PostException;
-import com.ripple.BE.post.persistence.PostLikeRepository;
-import com.ripple.BE.post.persistence.PostScrapRepository;
 import com.ripple.BE.post.persistence.ToktokRepository;
+import com.ripple.BE.post.persistence.dto.ToktokDetailDTO;
 import com.ripple.BE.post.persistence.dto.ToktokWithImageDTO;
 import com.ripple.BE.user.domain.User;
 import java.time.LocalDate;
@@ -38,8 +36,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class ToktokQueryService implements ToktokQueryUseCase {
 
     private final ToktokRepository toktokRepository;
-    private final PostLikeRepository postLikeRepository;
-    private final PostScrapRepository postScrapRepository;
     private final ImageRepository imageRepository;
 
     private final CommentQueryUseCase commentQueryUseCase;
@@ -66,22 +62,24 @@ public class ToktokQueryService implements ToktokQueryUseCase {
     @Override
     public ToktokResponseDTO getToktok(final long id, final long userId) {
 
-        Post toktok =
-                toktokRepository.findById(id).orElseThrow(() -> new PostException(POST_NOT_FOUND));
+        // 1. 댓글 제외한 정보만 쿼리로 조회
+        ToktokDetailDTO dto =
+                toktokRepository
+                        .findToktokDetail(id, userId)
+                        .orElseThrow(() -> new PostException(POST_NOT_FOUND));
 
-        if (toktok.getUsedDate() == null) {
-            throw new PostException(POST_NOT_FOUND);
-        }
+        // 2. 댓글 조회
+        List<CommentResponseDTO> commentDTOs = commentQueryUseCase.getComments(id, userId);
 
-        boolean isLiked = postLikeRepository.existsByPostIdAndUserId(id, userId);
-        boolean isScrapped = postScrapRepository.existsByPostIdAndUserId(id, userId);
+        // 3. 참여자 수 조회
+        long participantCount =
+                commentDTOs.stream().map(CommentResponseDTO::commenterId).distinct().count();
 
+        // 이미지 조회
         List<ImageResponse> imageResponses =
                 imageRepository.findByPostId(id).stream().map(ImageResponse::from).toList();
 
-        List<CommentResponseDTO> commentDTOs = commentQueryUseCase.getComments(toktok.getId(), userId);
-
-        return ToktokResponseDTO.of(toktok, imageResponses, commentDTOs, isScrapped, isLiked);
+        return ToktokResponseDTO.of(dto, imageResponses, commentDTOs, participantCount);
     }
 
     @Override

--- a/src/main/java/com/ripple/BE/post/dto/response/CommentResponseDTO.java
+++ b/src/main/java/com/ripple/BE/post/dto/response/CommentResponseDTO.java
@@ -29,7 +29,7 @@ public record CommentResponseDTO(
                 dto.likeCount(),
                 dto.commenterId(),
                 dto.commenterName(),
-                dto.profileImage() != null ? dto.profileImage().getS3Info().getUrl() : null,
+                dto.profileImageUrl(),
                 dto.isDeleted(),
                 isAuthor,
                 isLiked,

--- a/src/main/java/com/ripple/BE/post/dto/response/PostResponseDTO.java
+++ b/src/main/java/com/ripple/BE/post/dto/response/PostResponseDTO.java
@@ -2,9 +2,8 @@ package com.ripple.BE.post.dto.response;
 
 import com.ripple.BE.global.utils.RelativeTimeFormatter;
 import com.ripple.BE.image.dto.response.ImageResponse;
-import com.ripple.BE.post.domain.post.Post;
 import com.ripple.BE.post.domain.type.PostType;
-import com.ripple.BE.user.domain.User;
+import com.ripple.BE.post.persistence.dto.PostDetailDTO;
 import java.util.List;
 
 public record PostResponseDTO(
@@ -25,28 +24,22 @@ public record PostResponseDTO(
         String createdDate) {
 
     public static PostResponseDTO of(
-            Post post,
-            User author,
-            List<ImageResponse> imageList,
-            List<CommentResponseDTO> commentList,
-            boolean isScraped,
-            boolean isLiked,
-            boolean isAuthor) {
+            PostDetailDTO dto, List<ImageResponse> imageList, List<CommentResponseDTO> commentList) {
         return new PostResponseDTO(
-                post.getTitle(),
-                author.getNickname(),
-                post.getAuthorId(),
-                author.getProfileImage() == null ? null : author.getProfileImage().getS3Info().getUrl(),
-                post.getContent(),
-                post.getType(),
-                post.getLikeCount(),
-                post.getCommentCount(),
-                post.getScrapCount(),
-                isScraped,
-                isLiked,
-                isAuthor,
+                dto.title(),
+                dto.authorNickname(),
+                dto.authorId(),
+                dto.profileImageUrl(),
+                dto.content(),
+                dto.type(),
+                dto.likeCount(),
+                dto.commentCount(),
+                dto.scrapCount(),
+                dto.isScrapped(),
+                dto.isLiked(),
+                dto.isAuthor(),
                 imageList,
                 commentList,
-                RelativeTimeFormatter.formatRelativeTime(post.getCreatedDate()));
+                RelativeTimeFormatter.formatRelativeTime(dto.createdDate()));
     }
 }

--- a/src/main/java/com/ripple/BE/post/dto/response/ToktokResponseDTO.java
+++ b/src/main/java/com/ripple/BE/post/dto/response/ToktokResponseDTO.java
@@ -2,7 +2,7 @@ package com.ripple.BE.post.dto.response;
 
 import com.ripple.BE.global.utils.RelativeTimeFormatter;
 import com.ripple.BE.image.dto.response.ImageResponse;
-import com.ripple.BE.post.domain.post.Post;
+import com.ripple.BE.post.persistence.dto.ToktokDetailDTO;
 import java.util.List;
 
 public record ToktokResponseDTO(
@@ -18,21 +18,20 @@ public record ToktokResponseDTO(
         String createdDate) {
 
     public static ToktokResponseDTO of(
-            Post toktokPost,
+            ToktokDetailDTO dto,
             List<ImageResponse> imageList,
             List<CommentResponseDTO> commentList,
-            boolean isScraped,
-            boolean isLiked) {
+            long participantCount) {
         return new ToktokResponseDTO(
-                toktokPost.getTitle(),
-                toktokPost.getContent(),
-                toktokPost.getCommentCount(),
-                toktokPost.getLikeCount(),
-                toktokPost.getScrapCount(),
-                isScraped,
-                isLiked,
+                dto.title(),
+                dto.content(),
+                participantCount,
+                dto.likeCount(),
+                dto.scrapCount(),
+                dto.isScraped(),
+                dto.isLiked(),
                 imageList,
                 commentList,
-                RelativeTimeFormatter.formatRelativeTime(toktokPost.getCreatedDate()));
+                RelativeTimeFormatter.formatRelativeTime(dto.usedDate().atStartOfDay()));
     }
 }

--- a/src/main/java/com/ripple/BE/post/persistence/PostRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/PostRepository.java
@@ -3,6 +3,7 @@ package com.ripple.BE.post.persistence;
 import com.ripple.BE.post.domain.post.Post;
 import com.ripple.BE.post.domain.type.PostSort;
 import com.ripple.BE.post.domain.type.PostType;
+import com.ripple.BE.post.persistence.dto.PostDetailDTO;
 import com.ripple.BE.post.persistence.dto.PostWithImageDTO;
 import java.util.List;
 import java.util.Optional;
@@ -37,6 +38,9 @@ public interface PostRepository {
 
     // 게시글 ID 목록을 통해 게시글을 조회한다.
     List<PostWithImageDTO> findByIdIn(final List<Long> postIds);
+
+    // 게시물의 상세 정보를 조회한다.
+    Optional<PostDetailDTO> findPostDetail(final long postId, final long userId);
 
     List<Post> findAllByAuthorId(final long authorId);
 

--- a/src/main/java/com/ripple/BE/post/persistence/ToktokRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/ToktokRepository.java
@@ -2,6 +2,7 @@ package com.ripple.BE.post.persistence;
 
 import com.ripple.BE.post.domain.post.Post;
 import com.ripple.BE.post.domain.type.PostSort;
+import com.ripple.BE.post.persistence.dto.ToktokDetailDTO;
 import com.ripple.BE.post.persistence.dto.ToktokWithImageDTO;
 import com.ripple.BE.user.domain.User;
 import java.time.LocalDate;
@@ -34,4 +35,6 @@ public interface ToktokRepository {
     Page<ToktokWithImageDTO> searchUsedToktokPosts(final String keyword, final Pageable pageable);
 
     Map<Long, List<User>> findUsersByToktokPostIds(List<Long> postIds);
+
+    Optional<ToktokDetailDTO> findToktokDetail(final long postId, final long userId);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/dto/CommentWithUserDTO.java
+++ b/src/main/java/com/ripple/BE/post/persistence/dto/CommentWithUserDTO.java
@@ -1,6 +1,5 @@
 package com.ripple.BE.post.persistence.dto;
 
-import com.ripple.BE.image.persistence.jpa.entity.ImageJpaEntity;
 import java.time.LocalDateTime;
 
 public record CommentWithUserDTO(
@@ -12,5 +11,5 @@ public record CommentWithUserDTO(
         boolean isDeleted,
         Long commenterId,
         String commenterName,
-        ImageJpaEntity profileImage,
+        String profileImageUrl,
         LocalDateTime createdDate) {}

--- a/src/main/java/com/ripple/BE/post/persistence/dto/PostDetailDTO.java
+++ b/src/main/java/com/ripple/BE/post/persistence/dto/PostDetailDTO.java
@@ -1,0 +1,20 @@
+package com.ripple.BE.post.persistence.dto;
+
+import com.ripple.BE.post.domain.type.PostType;
+import java.time.LocalDateTime;
+
+public record PostDetailDTO(
+        Long postId,
+        String title,
+        String content,
+        Long authorId,
+        String authorNickname,
+        String profileImageUrl,
+        PostType type,
+        long likeCount,
+        long scrapCount,
+        long commentCount,
+        boolean isLiked,
+        boolean isScrapped,
+        boolean isAuthor,
+        LocalDateTime createdDate) {}

--- a/src/main/java/com/ripple/BE/post/persistence/dto/ToktokDetailDTO.java
+++ b/src/main/java/com/ripple/BE/post/persistence/dto/ToktokDetailDTO.java
@@ -1,0 +1,12 @@
+package com.ripple.BE.post.persistence.dto;
+
+import java.time.LocalDate;
+
+public record ToktokDetailDTO(
+        String title,
+        String content,
+        long likeCount,
+        long scrapCount,
+        boolean isScraped,
+        boolean isLiked,
+        LocalDate usedDate) {}

--- a/src/main/java/com/ripple/BE/post/persistence/impl/post/PostRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/impl/post/PostRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.ripple.BE.post.domain.post.Post;
 import com.ripple.BE.post.domain.type.PostSort;
 import com.ripple.BE.post.domain.type.PostType;
 import com.ripple.BE.post.persistence.PostRepository;
+import com.ripple.BE.post.persistence.dto.PostDetailDTO;
 import com.ripple.BE.post.persistence.dto.PostWithImageDTO;
 import com.ripple.BE.post.persistence.jpa.entity.PostJpaEntity;
 import com.ripple.BE.post.persistence.jpa.repository.post.PostJpaRepository;
@@ -71,6 +72,11 @@ public class PostRepositoryImpl implements PostRepository {
     @Override
     public List<PostWithImageDTO> findByIdIn(final List<Long> postIds) {
         return postJpaRepository.findByIdIn(postIds);
+    }
+
+    @Override
+    public Optional<PostDetailDTO> findPostDetail(final long postId, final long userId) {
+        return postJpaRepository.findPostDetail(postId, userId);
     }
 
     @Override

--- a/src/main/java/com/ripple/BE/post/persistence/impl/toktok/ToktokRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/impl/toktok/ToktokRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.ripple.BE.post.persistence.impl.toktok;
 import com.ripple.BE.post.domain.post.Post;
 import com.ripple.BE.post.domain.type.PostSort;
 import com.ripple.BE.post.persistence.ToktokRepository;
+import com.ripple.BE.post.persistence.dto.ToktokDetailDTO;
 import com.ripple.BE.post.persistence.dto.ToktokWithImageDTO;
 import com.ripple.BE.post.persistence.jpa.entity.PostJpaEntity;
 import com.ripple.BE.post.persistence.jpa.repository.comment.CommentJpaRepository;
@@ -78,5 +79,10 @@ public class ToktokRepositoryImpl implements ToktokRepository {
     @Override
     public Map<Long, List<User>> findUsersByToktokPostIds(final List<Long> postIds) {
         return commentJpaRepository.findUsersByToktokPostIds(postIds);
+    }
+
+    @Override
+    public Optional<ToktokDetailDTO> findToktokDetail(final long postId, final long userId) {
+        return toktokJpaRepository.findToktokDetail(postId, userId);
     }
 }

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/comment/CommentQueryRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/comment/CommentQueryRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.ripple.BE.post.persistence.jpa.repository.comment;
 
+import static com.ripple.BE.image.persistence.jpa.entity.QImageJpaEntity.*;
 import static com.ripple.BE.post.persistence.jpa.entity.QCommentJpaEntity.*;
 import static com.ripple.BE.post.persistence.jpa.entity.QPostJpaEntity.*;
 import static com.ripple.BE.user.domain.QUser.*;
@@ -65,12 +66,12 @@ public class CommentQueryRepositoryImpl implements CommentQueryRepository {
                                         commentJpaEntity.isDeleted,
                                         user.id,
                                         user.nickname,
-                                        user.profileImage,
+                                        user.profileImage.s3Info.url,
                                         commentJpaEntity.createdDate))
                         .from(commentJpaEntity)
                         .leftJoin(user)
                         .on(commentJpaEntity.commenterId.eq(user.id))
-                        .leftJoin(user.profileImage)
+                        .leftJoin(user.profileImage, imageJpaEntity)
                         .where(commentJpaEntity.postId.eq(postId))
                         .fetch();
 

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/post/PostQueryRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/post/PostQueryRepository.java
@@ -2,8 +2,10 @@ package com.ripple.BE.post.persistence.jpa.repository.post;
 
 import com.ripple.BE.post.domain.type.PostSort;
 import com.ripple.BE.post.domain.type.PostType;
+import com.ripple.BE.post.persistence.dto.PostDetailDTO;
 import com.ripple.BE.post.persistence.dto.PostWithImageDTO;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -20,4 +22,6 @@ public interface PostQueryRepository {
     List<PostWithImageDTO> findUserNormalPosts(long userId);
 
     List<PostWithImageDTO> findByIdIn(List<Long> ids);
+
+    Optional<PostDetailDTO> findPostDetail(long postId, long userId);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/post/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/post/PostQueryRepositoryImpl.java
@@ -2,6 +2,9 @@ package com.ripple.BE.post.persistence.jpa.repository.post;
 
 import static com.ripple.BE.image.persistence.jpa.entity.QImageJpaEntity.*;
 import static com.ripple.BE.post.persistence.jpa.entity.QPostJpaEntity.*;
+import static com.ripple.BE.post.persistence.jpa.entity.QPostLikeJpaEntity.*;
+import static com.ripple.BE.post.persistence.jpa.entity.QPostScrapJpaEntity.*;
+import static com.ripple.BE.user.domain.QUser.*;
 
 import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.OrderSpecifier;
@@ -12,8 +15,10 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ripple.BE.post.domain.type.PostSort;
 import com.ripple.BE.post.domain.type.PostType;
+import com.ripple.BE.post.persistence.dto.PostDetailDTO;
 import com.ripple.BE.post.persistence.dto.PostWithImageDTO;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -107,6 +112,50 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
                 .where(predicate)
                 .orderBy(postJpaEntity.createdDate.desc())
                 .fetch();
+    }
+
+    @Override
+    public Optional<PostDetailDTO> findPostDetail(long postId, long userId) {
+        return Optional.ofNullable(
+                queryFactory
+                        .select(
+                                Projections.constructor(
+                                        PostDetailDTO.class,
+                                        postJpaEntity.id, // 1. postId
+                                        postJpaEntity.title, // 2. title
+                                        postJpaEntity.content, // 3. content
+                                        user.id, // 4. authorId
+                                        user.nickname, // 5. authorNickname
+                                        user.profileImage.s3Info.url, // 6. profileImageUrl
+                                        postJpaEntity.type, // 7. PostType
+                                        postJpaEntity.likeCount, // 8. likeCount
+                                        postJpaEntity.scrapCount, // 9. scrapCount
+                                        postJpaEntity.commentCount, // 10. commentCount
+                                        JPAExpressions.select(postLikeJpaEntity.count()) // 11. isLiked
+                                                .from(postLikeJpaEntity)
+                                                .where(
+                                                        postLikeJpaEntity
+                                                                .postId
+                                                                .eq(postId)
+                                                                .and(postLikeJpaEntity.userId.eq(userId)))
+                                                .gt(0L),
+                                        JPAExpressions.select(postScrapJpaEntity.count()) // 12. isScrapped
+                                                .from(postScrapJpaEntity)
+                                                .where(
+                                                        postScrapJpaEntity
+                                                                .postId
+                                                                .eq(postId)
+                                                                .and(postScrapJpaEntity.userId.eq(userId)))
+                                                .gt(0L),
+                                        postJpaEntity.authorId.eq(userId), // 13. isAuthor
+                                        postJpaEntity.createdDate // 14. createdDate
+                                        ))
+                        .from(postJpaEntity)
+                        .leftJoin(user)
+                        .on(postJpaEntity.authorId.eq(user.id))
+                        .leftJoin(user.profileImage, imageJpaEntity)
+                        .where(postJpaEntity.id.eq(postId))
+                        .fetchOne());
     }
 
     // 공통 정렬 조건

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/post/ToktokQueryRepository.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/post/ToktokQueryRepository.java
@@ -1,6 +1,7 @@
 package com.ripple.BE.post.persistence.jpa.repository.post;
 
 import com.ripple.BE.post.domain.type.PostSort;
+import com.ripple.BE.post.persistence.dto.ToktokDetailDTO;
 import com.ripple.BE.post.persistence.dto.ToktokWithImageDTO;
 import com.ripple.BE.post.persistence.jpa.entity.PostJpaEntity;
 import java.time.LocalDate;
@@ -21,4 +22,6 @@ public interface ToktokQueryRepository {
     Optional<ToktokWithImageDTO> findByUsedDate(LocalDate usedDate);
 
     Page<ToktokWithImageDTO> searchUsedToktokPosts(String keyword, Pageable pageable);
+
+    Optional<ToktokDetailDTO> findToktokDetail(long postId, long userId);
 }

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/post/ToktokQueryRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/post/ToktokQueryRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.ripple.BE.post.persistence.jpa.repository.post;
 
 import static com.ripple.BE.image.persistence.jpa.entity.QImageJpaEntity.*;
 import static com.ripple.BE.post.persistence.jpa.entity.QPostJpaEntity.*;
+import static com.ripple.BE.post.persistence.jpa.entity.QPostLikeJpaEntity.*;
+import static com.ripple.BE.post.persistence.jpa.entity.QPostScrapJpaEntity.*;
 
 import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.OrderSpecifier;
@@ -12,6 +14,7 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ripple.BE.post.domain.type.PostSort;
 import com.ripple.BE.post.domain.type.PostType;
+import com.ripple.BE.post.persistence.dto.ToktokDetailDTO;
 import com.ripple.BE.post.persistence.dto.ToktokWithImageDTO;
 import com.ripple.BE.post.persistence.jpa.entity.PostJpaEntity;
 import java.time.LocalDate;
@@ -101,6 +104,48 @@ public class ToktokQueryRepositoryImpl implements ToktokQueryRepository {
         ToktokWithImageDTO dto =
                 jpaQueryFactory
                         .select(toktokPreviewProjection())
+                        .from(postJpaEntity)
+                        .where(predicate)
+                        .fetchOne();
+
+        return Optional.ofNullable(dto);
+    }
+
+    @Override
+    public Optional<ToktokDetailDTO> findToktokDetail(long postId, long userId) {
+        BooleanExpression predicate =
+                postJpaEntity
+                        .id
+                        .eq(postId)
+                        .and(postJpaEntity.type.eq(PostType.ECONOMY_TALK))
+                        .and(postJpaEntity.usedDate.isNotNull());
+
+        ToktokDetailDTO dto =
+                jpaQueryFactory
+                        .select(
+                                Projections.constructor(
+                                        ToktokDetailDTO.class,
+                                        postJpaEntity.title,
+                                        postJpaEntity.content,
+                                        postJpaEntity.likeCount,
+                                        postJpaEntity.scrapCount,
+                                        JPAExpressions.select(postScrapJpaEntity.id.count())
+                                                .from(postScrapJpaEntity)
+                                                .where(
+                                                        postScrapJpaEntity
+                                                                .postId
+                                                                .eq(postId)
+                                                                .and(postScrapJpaEntity.userId.eq(userId)))
+                                                .gt(0L),
+                                        JPAExpressions.select(postLikeJpaEntity.id.count())
+                                                .from(postLikeJpaEntity)
+                                                .where(
+                                                        postLikeJpaEntity
+                                                                .postId
+                                                                .eq(postId)
+                                                                .and(postLikeJpaEntity.userId.eq(userId)))
+                                                .gt(0L),
+                                        postJpaEntity.usedDate))
                         .from(postJpaEntity)
                         .where(predicate)
                         .fetchOne();


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #122 

## 📝작업 내용

> Toktok 게시글 상세/리스트 조회 및 댓글 응답 구조 개선 작업을 진행했습니다. QueryDSL의 @QueryProjection을 활용해 DTO 생성자 기반 직접 매핑을 적용하여 쿼리 최적화와 성능 개선을 도모했습니다.

- @QueryProjection 적용을 통해 select 절에서 필요한 필드만 추출하도록 쿼리 최적화
- PostDetailDTO, ToktokDetailDTO, ToktokResponseDTO, CommentWithUserDTO 등 DTO 생성자에 @QueryProjection 어노테이션 추가 및 Q클래스 생성
- 게시글 상세 조회 시 아래 정보 추가:
   - 작성자 프로필 이미지 URL
   - 좋아요 여부, 스크랩 여부, 작성자인지 여부(Boolean)
- 댓글 리스트 조회 시 댓글 작성자 프로필 이미지 URL 포함
- createdDate → usedDate 필드로 변경하여 실사용 기준 반영
- 댓글 수 → 댓글 작성자 수로 변경 (distinct count 처리)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?