### PR TITLE
[Debug] 애플리케이션 강제 종료 시 알람 예외 처리

### DIFF
--- a/src/main/java/com/ripple/BE/learning/persistence/impl/UserLearningSetRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/learning/persistence/impl/UserLearningSetRepositoryImpl.java
@@ -59,7 +59,7 @@ public class UserLearningSetRepositoryImpl implements UserLearningSetRepository 
     public void deleteAllByUserId(final long userId) {
         userLearningSetJpaRepository.deleteAllByUserId(userId);
     }
-  
+
     @Override
     public List<UserLearningSet> findByUserIdAndLearningSetId(long userId, long learningSetId) {
         return userLearningSetJpaRepository.findByUserIdAndLearningSetId(userId, learningSetId).stream()

--- a/src/main/java/com/ripple/BE/notification/application/sse/SseEmitterManager.java
+++ b/src/main/java/com/ripple/BE/notification/application/sse/SseEmitterManager.java
@@ -116,10 +116,18 @@ public class SseEmitterManager {
             Future<?> shutdownTask =
                     threadPoolTaskExecutor.submit(
                             () -> {
-                                if (cause != null) emitter.completeWithError(cause);
-                                else emitter.complete();
+                                try {
+                                    if (cause instanceof IOException) { // IOException은 클라이언트 연결 문제
+                                        emitter.complete();
+                                    } else if (cause != null) {
+                                        emitter.completeWithError(cause);
+                                    } else {
+                                        emitter.complete();
+                                    }
+                                } catch (Exception e) {
+                                    log.error("Emitter 종료 중 오류 발생: {}", clientId, e);
+                                }
                             });
-
             try {
                 shutdownTask.get(5, TimeUnit.SECONDS);
             } catch (InterruptedException | ExecutionException | TimeoutException e) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #117 

## 📝작업 내용

- 클라이언트가 앱을 강제 종료했을 때 발생하는 IOException을 completeWithError() 대신 complete() 처리하여 불필요한 에러 로그 억제
- emitter 중복 종료 방지 및 하트비트 스케줄 안전 종료 처리
- 알림 전송 시 emitter가 없을 경우 로그 출력 추가

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?