### PR TITLE
[Refactor] SSEEmitter 종료 로직 비동기 처리 및 간소화 (#117)

### DIFF
--- a/src/main/java/com/ripple/BE/notification/application/sse/SseEmitterManager.java
+++ b/src/main/java/com/ripple/BE/notification/application/sse/SseEmitterManager.java
@@ -6,8 +6,6 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -105,35 +103,29 @@ public class SseEmitterManager {
 
     /** 연결 종료 처리 */
     private void closeEmitter(String clientId, Throwable cause) {
-        emitterClosedMap.computeIfAbsent(clientId, k -> false);
-        if (Boolean.TRUE.equals(emitterClosedMap.get(clientId))) return;
+        if (Boolean.TRUE.equals(emitterClosedMap.getOrDefault(clientId, false))) {
+            return;
+        }
 
         emitterClosedMap.put(clientId, true);
         SseEmitter emitter = emitterMap.remove(clientId);
         stopHeartbeat(clientId);
 
-        if (emitter != null) {
-            Future<?> shutdownTask =
-                    threadPoolTaskExecutor.submit(
-                            () -> {
-                                try {
-                                    if (cause instanceof IOException) { // IOException은 클라이언트 연결 문제
-                                        emitter.complete();
-                                    } else if (cause != null) {
-                                        emitter.completeWithError(cause);
-                                    } else {
-                                        emitter.complete();
-                                    }
-                                } catch (Exception e) {
-                                    log.error("Emitter 종료 중 오류 발생: {}", clientId, e);
-                                }
-                            });
-            try {
-                shutdownTask.get(5, TimeUnit.SECONDS);
-            } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                log.error("Emitter 종료 실패", e);
-            }
+        if (emitter == null) {
+            return;
         }
+
+        threadPoolTaskExecutor.submit(
+                () -> {
+                    try {
+                        if (cause != null) {
+                            log.info("Emitter 종료: {}, 원인: {}", clientId, cause.getMessage());
+                        }
+                        emitter.complete();
+                    } catch (Exception e) {
+                        log.error("Emitter 종료 중 오류 발생: {}", clientId, e);
+                    }
+                });
     }
 
     /** 하트비트 정지 */


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #117

## 📝작업 내용


- emitterClosedMap.computeIfAbsent() → getOrDefault()로 변경하여 가독성 개선
- Future#get() 제거로 불필요한 블로킹 제거 및 간결한 로직 유지
- emitter.complete() 호출을 threadPoolTaskExecutor.submit() 내부에서 비동기 처리
- null 체크 및 불필요한 흐름 제거로 코드 정돈

📌 shutdownTask.get() 호출 제거로 인해 emitter 종료 여부를 기다리지 않고 반환합니다. emitter 종료 성공 여부에 민감하지 않은 상황을 가정하고 리팩토링한 방식입니다.




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?