### PR TITLE
[Fix] 소셜 로그인 시 UserLearningSet 중복 생성 방지 (#134)

### DIFF
--- a/src/main/java/com/ripple/BE/user/service/UserService.java
+++ b/src/main/java/com/ripple/BE/user/service/UserService.java
@@ -85,15 +85,18 @@ public class UserService {
 
     @Transactional
     public Long findOrCreateUser(KakaoUserInfoResponse response) {
+        Optional<User> optionalUser = userRepository.findByKeyCode(response.id().toString());
+
+        if (optionalUser.isPresent()) {
+            return optionalUser.get().getId(); // 이미 존재하는 경우 이벤트 없이 바로 반환
+        }
+
         User user =
-                userRepository
-                        .findByKeyCode(response.id().toString())
-                        .orElse(
-                                User.kakaoBuilder()
-                                        .accountEmail(response.kakao_account().email())
-                                        .loginType(LoginType.KAKAO)
-                                        .keyCode(response.id().toString())
-                                        .buildKakaoUser());
+                User.kakaoBuilder()
+                        .accountEmail(response.kakao_account().email())
+                        .loginType(LoginType.KAKAO)
+                        .keyCode(response.id().toString())
+                        .buildKakaoUser();
 
         user = userRepository.save(user);
 


### PR DESCRIPTION
> 이미 존재하는 사용자임에도 UserCreatedEvent가 발행되어 UserLearningSet이 중복 생성되는 문제 수정

## #️⃣연관된 이슈

> #134 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

-  이미 존재하는 사용자에 대해 UserCreatedEvent 발행을 생략하도록 findOrCreateUser() 로직 수정
-  기존 사용자에 대한 중복 이벤트 발행으로 인해 발생하는 UserLearningSet 중복 생성 버그 수정
-




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?