### PR TITLE
[Feat] Toktok 미리보기 DTO에 참여자 수(participantCount) 필드 추가 (#136)

### DIFF
--- a/src/main/java/com/ripple/BE/post/dto/response/ToktokPreviewResponseDTO.java
+++ b/src/main/java/com/ripple/BE/post/dto/response/ToktokPreviewResponseDTO.java
@@ -9,6 +9,7 @@ public record ToktokPreviewResponseDTO(
         Long id,
         String title,
         long participantCount,
+        long commentCount,
         long likeCount,
         long scrapCount,
         String imageUrl,
@@ -27,6 +28,7 @@ public record ToktokPreviewResponseDTO(
         return new ToktokPreviewResponseDTO(
                 dto.id(),
                 dto.title(),
+                dto.participantCount(),
                 dto.commentCount(),
                 dto.likeCount(),
                 dto.scrapCount(),

--- a/src/main/java/com/ripple/BE/post/persistence/dto/ToktokWithImageDTO.java
+++ b/src/main/java/com/ripple/BE/post/persistence/dto/ToktokWithImageDTO.java
@@ -11,5 +11,6 @@ public record ToktokWithImageDTO(
         long likeCount,
         long commentCount,
         long scrapCount,
+        long participantCount,
         String imageUrl,
         LocalDate usedDate) {}

--- a/src/main/java/com/ripple/BE/post/persistence/jpa/repository/post/ToktokQueryRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/post/persistence/jpa/repository/post/ToktokQueryRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.ripple.BE.post.persistence.jpa.repository.post;
 
 import static com.ripple.BE.image.persistence.jpa.entity.QImageJpaEntity.*;
+import static com.ripple.BE.post.persistence.jpa.entity.QCommentJpaEntity.*;
 import static com.ripple.BE.post.persistence.jpa.entity.QPostJpaEntity.*;
 import static com.ripple.BE.post.persistence.jpa.entity.QPostLikeJpaEntity.*;
 import static com.ripple.BE.post.persistence.jpa.entity.QPostScrapJpaEntity.*;
@@ -163,6 +164,9 @@ public class ToktokQueryRepositoryImpl implements ToktokQueryRepository {
                 postJpaEntity.likeCount,
                 postJpaEntity.commentCount,
                 postJpaEntity.scrapCount,
+                JPAExpressions.select(commentJpaEntity.commenterId.countDistinct())
+                        .from(commentJpaEntity)
+                        .where(commentJpaEntity.postId.eq(postJpaEntity.id)),
                 JPAExpressions.select(imageJpaEntity.s3Info.url)
                         .from(imageJpaEntity)
                         .where(imageJpaEntity.postId.eq(postJpaEntity.id))

--- a/src/main/java/com/ripple/BE/user/domain/User.java
+++ b/src/main/java/com/ripple/BE/user/domain/User.java
@@ -80,7 +80,7 @@ public class User extends BaseJpaEntity {
     @Column(name = "login_type", nullable = false)
     private LoginType loginType;
 
-    @Size(min = 1, max = 255)
+    @Size(max = 255)
     @Column(name = "profile_intro")
     private String profileIntro; // 한줄 소개
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #136 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- ToktokPreviewResponseDTO, ToktokWithImageDTO에 participantCount 필드 추가
- ToktokQueryRepositoryImpl에서 참여자 수(participantCount) 계산 및 DTO에 포함되도록 수정
- 참여자 수는 해당 게시글의 댓글을 단 유저 수의 중복 제거(distinct)로 집계됨

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?