### PR TITLE
[Bug] 프로필 이미지 등록 시 Transient 예외 및 댓글 작성자 탈퇴 시 Null 예외 처리

### DIFF
--- a/src/main/java/com/ripple/BE/post/application/impl/common/CommentQueryService.java
+++ b/src/main/java/com/ripple/BE/post/application/impl/common/CommentQueryService.java
@@ -74,7 +74,7 @@ public class CommentQueryService implements CommentQueryUseCase {
     }
 
     private boolean isAuthor(CommentWithUserDTO comment, long userId) {
-        return comment.commenterId().equals(userId);
+        return comment.commenterId() != null && comment.commenterId().equals(userId);
     }
 
     private boolean isLiked(CommentWithUserDTO comment, Set<Long> likedIds) {

--- a/src/main/java/com/ripple/BE/user/service/UserService.java
+++ b/src/main/java/com/ripple/BE/user/service/UserService.java
@@ -146,6 +146,9 @@ public class UserService {
             user.updateProfileImage(ImageJpaEntity.from(image)); // 추후 수정 필요
         }
         user.updateProfile(request);
+
+        userRepository.save(user); // 프로필 업데이트 후 저장
+
         attendanceService.createAttendance(user);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #138 

## 📝작업 내용

> 댓글 조회 및 프로필 이미지 등록 시 발생하던 예외를 처리했습니다.

- CommentQueryService에서 commenterId가 null인 경우 NPE가 발생하지 않도록 방어 로직 추가
- UserService에서 프로필 이미지 업데이트 후 userRepository.save()를 명시적으로 호출하여 영속성 컨텍스트 외의 객체 저장 문제 해결
- 탈퇴 유저 및 비정상 상태 사용자 관련 예외 방지 로직 적용



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?