### PR TITLE
[Feat] 용어사전 검색 정확도 개선 (#141)

### DIFF
--- a/src/main/java/com/ripple/BE/term/persistence/jdbc/TermJdbcRepository.java
+++ b/src/main/java/com/ripple/BE/term/persistence/jdbc/TermJdbcRepository.java
@@ -64,7 +64,7 @@ public class TermJdbcRepository {
 		String countSql = """
 			SELECT COUNT(*)
 			FROM terms t
-			WHERE MATCH(t.title, t.description) AGAINST (? IN BOOLEAN MODE)
+			WHERE MATCH(t.title, t.description) AGAINST (? IN NATURAL LANGUAGE MODE)
 			""";
 
 		return getTermWithScrapDTOS(keyword, pageable, userId, searchSql, countSql);

--- a/src/main/java/com/ripple/BE/term/persistence/jdbc/TermJdbcRepository.java
+++ b/src/main/java/com/ripple/BE/term/persistence/jdbc/TermJdbcRepository.java
@@ -64,7 +64,7 @@ public class TermJdbcRepository {
 		String countSql = """
 			SELECT COUNT(*)
 			FROM terms t
-			WHERE MATCH(t.title, t.description) AGAINST (? IN NATURAL LANGUAGE MODE)
+			WHERE MATCH(t.title, t.description) AGAINST (? IN BOOLEAN MODE)
 			""";
 
 		return getTermWithScrapDTOS(keyword, buildBooleanKeyword(keyword), pageable, userId, searchSql, countSql);

--- a/src/main/java/com/ripple/BE/term/persistence/jdbc/TermJdbcRepository.java
+++ b/src/main/java/com/ripple/BE/term/persistence/jdbc/TermJdbcRepository.java
@@ -64,7 +64,7 @@ public class TermJdbcRepository {
 			WHERE MATCH(t.title, t.description) AGAINST (? IN NATURAL LANGUAGE MODE)
 			""";
 
-		return getTermWithScrapDTOS(keyword, '"' + keyword.trim().toLowerCase(Locale.ROOT) + "*\"", pageable, userId, searchSql, countSql);
+		return getTermWithScrapDTOS(keyword, buildBooleanKeyword(keyword), pageable, userId, searchSql, countSql);
 	}
 
 	private Page<TermWithScrapDTO> getTermWithScrapDTOS(String keyword, String booleanKeyword, Pageable pageable, long userId,
@@ -88,6 +88,10 @@ public class TermJdbcRepository {
 		Integer total = jdbcTemplate.queryForObject(countSql, Integer.class, keyword);
 
 		return PageableExecutionUtils.getPage(content, pageable, () -> total != null ? total : 0);
+	}
+
+	private static String buildBooleanKeyword(String keyword) {
+		return '"' + keyword.trim().toLowerCase(Locale.ROOT) + "*\"";
 	}
 
 }

--- a/src/main/java/com/ripple/BE/term/persistence/jdbc/TermJdbcRepository.java
+++ b/src/main/java/com/ripple/BE/term/persistence/jdbc/TermJdbcRepository.java
@@ -49,8 +49,11 @@ public class TermJdbcRepository {
 
 		String searchSql = """
 			SELECT t.id, t.title, t.description, t.initial,
-			       IF(ts.id IS NOT NULL, true, false) AS is_scrapped,
-					MATCH(t.title, t.description) AGAINST (? IN NATURAL LANGUAGE MODE) AS score
+				IF(ts.id IS NOT NULL, true, false) AS is_scrapped,
+			    (
+			    	1.5 * MATCH(t.title) AGAINST (? IN NATURAL LANGUAGE MODE) +
+			    	0.5 * MATCH(t.description) AGAINST (? IN NATURAL LANGUAGE MODE)
+			    ) AS score
 			FROM terms t
 			LEFT JOIN term_scraps ts ON t.id = ts.term_id AND ts.user_id = ?
 			WHERE MATCH(t.title, t.description) AGAINST (? IN BOOLEAN MODE)
@@ -78,6 +81,7 @@ public class TermJdbcRepository {
 				rs.getString("initial"),
 				rs.getBoolean("is_scrapped")
 			),
+			keyword,
 			keyword,
 			userId,
 			booleanKeyword,

--- a/src/main/java/com/ripple/BE/term/persistence/jdbc/TermJdbcRepository.java
+++ b/src/main/java/com/ripple/BE/term/persistence/jdbc/TermJdbcRepository.java
@@ -4,6 +4,7 @@ import com.ripple.BE.term.persistence.dto.TermWithScrapDTO;
 import com.ripple.BE.term.persistence.jpa.entity.TermJpaEntity;
 
 import java.util.List;
+import java.util.Locale;
 
 import lombok.RequiredArgsConstructor;
 
@@ -48,11 +49,12 @@ public class TermJdbcRepository {
 
 		String searchSql = """
 			SELECT t.id, t.title, t.description, t.initial,
-			       IF(ts.id IS NOT NULL, true, false) AS is_scrapped
+			       IF(ts.id IS NOT NULL, true, false) AS is_scrapped,
+					MATCH(t.title, t.description) AGAINST (? IN NATURAL LANGUAGE MODE) AS score
 			FROM terms t
 			LEFT JOIN term_scraps ts ON t.id = ts.term_id AND ts.user_id = ?
-			WHERE MATCH(t.title, t.description) AGAINST (? IN NATURAL LANGUAGE MODE)
-			ORDER BY t.id DESC
+			WHERE MATCH(t.title, t.description) AGAINST (? IN BOOLEAN MODE)
+			ORDER BY score DESC
 			LIMIT ? OFFSET ?
 			""";
 
@@ -62,7 +64,7 @@ public class TermJdbcRepository {
 			WHERE MATCH(t.title, t.description) AGAINST (? IN NATURAL LANGUAGE MODE)
 			""";
 
-		return getTermWithScrapDTOS(keyword, pageable, userId, searchSql, countSql);
+		return getTermWithScrapDTOS(keyword, '"' + keyword.trim().toLowerCase(Locale.ROOT) + "*\"", pageable, userId, searchSql, countSql);
 	}
 
 	@Transactional(readOnly = true)
@@ -87,10 +89,10 @@ public class TermJdbcRepository {
 			WHERE MATCH(t.title) AGAINST (? IN NATURAL LANGUAGE MODE)
 			""";
 
-		return getTermWithScrapDTOS(keyword, pageable, userId, searchSql, countSql);
+		return getTermWithScrapDTOS(keyword, '"' + keyword.trim().toLowerCase(Locale.ROOT) + "*\"", pageable, userId, searchSql, countSql);
 	}
 
-	private Page<TermWithScrapDTO> getTermWithScrapDTOS(String keyword, Pageable pageable, long userId,
+	private Page<TermWithScrapDTO> getTermWithScrapDTOS(String keyword, String booleanKeyword, Pageable pageable, long userId,
 		String searchSql, String countSql) {
 		List<TermWithScrapDTO> content = jdbcTemplate.query(
 			searchSql,
@@ -101,8 +103,9 @@ public class TermJdbcRepository {
 				rs.getString("initial"),
 				rs.getBoolean("is_scrapped")
 			),
-			userId,
 			keyword,
+			userId,
+			booleanKeyword,
 			pageable.getPageSize(),
 			pageable.getOffset()
 		);

--- a/src/main/java/com/ripple/BE/term/persistence/jdbc/TermJdbcRepository.java
+++ b/src/main/java/com/ripple/BE/term/persistence/jdbc/TermJdbcRepository.java
@@ -67,31 +67,6 @@ public class TermJdbcRepository {
 		return getTermWithScrapDTOS(keyword, '"' + keyword.trim().toLowerCase(Locale.ROOT) + "*\"", pageable, userId, searchSql, countSql);
 	}
 
-	@Transactional(readOnly = true)
-	public Page<TermWithScrapDTO> findByKeyword(String keyword, Pageable pageable, long userId) {
-		if (keyword == null || keyword.trim().isEmpty()) {
-			return Page.empty(pageable);
-		}
-
-		String searchSql = """
-			SELECT t.id, t.title, t.description, t.initial,
-			       IF(ts.id IS NOT NULL, true, false) AS is_scrapped
-			FROM terms t
-			LEFT JOIN term_scraps ts ON t.id = ts.term_id AND ts.user_id = ?
-			WHERE MATCH(t.title) AGAINST (? IN NATURAL LANGUAGE MODE)
-			ORDER BY t.id DESC
-			LIMIT ? OFFSET ?
-			""";
-
-		String countSql = """
-			SELECT COUNT(*)
-			FROM terms t
-			WHERE MATCH(t.title) AGAINST (? IN NATURAL LANGUAGE MODE)
-			""";
-
-		return getTermWithScrapDTOS(keyword, '"' + keyword.trim().toLowerCase(Locale.ROOT) + "*\"", pageable, userId, searchSql, countSql);
-	}
-
 	private Page<TermWithScrapDTO> getTermWithScrapDTOS(String keyword, String booleanKeyword, Pageable pageable, long userId,
 		String searchSql, String countSql) {
 		List<TermWithScrapDTO> content = jdbcTemplate.query(

--- a/src/main/java/com/ripple/BE/term/persistence/jdbc/TermJdbcRepository.java
+++ b/src/main/java/com/ripple/BE/term/persistence/jdbc/TermJdbcRepository.java
@@ -56,7 +56,7 @@ public class TermJdbcRepository {
 			    ) AS score
 			FROM terms t
 			LEFT JOIN term_scraps ts ON t.id = ts.term_id AND ts.user_id = ?
-			WHERE MATCH(t.title, t.description) AGAINST (? IN BOOLEAN MODE)
+			WHERE MATCH(t.title, t.description) AGAINST (? IN NATURAL LANGUAGE MODE)
 			ORDER BY score DESC
 			LIMIT ? OFFSET ?
 			""";
@@ -67,10 +67,10 @@ public class TermJdbcRepository {
 			WHERE MATCH(t.title, t.description) AGAINST (? IN BOOLEAN MODE)
 			""";
 
-		return getTermWithScrapDTOS(keyword, buildBooleanKeyword(keyword), pageable, userId, searchSql, countSql);
+		return getTermWithScrapDTOS(keyword, pageable, userId, searchSql, countSql);
 	}
 
-	private Page<TermWithScrapDTO> getTermWithScrapDTOS(String keyword, String booleanKeyword, Pageable pageable, long userId,
+	private Page<TermWithScrapDTO> getTermWithScrapDTOS(String keyword, Pageable pageable, long userId,
 		String searchSql, String countSql) {
 		List<TermWithScrapDTO> content = jdbcTemplate.query(
 			searchSql,
@@ -84,7 +84,7 @@ public class TermJdbcRepository {
 			keyword,
 			keyword,
 			userId,
-			booleanKeyword,
+			keyword,
 			pageable.getPageSize(),
 			pageable.getOffset()
 		);
@@ -92,10 +92,6 @@ public class TermJdbcRepository {
 		Integer total = jdbcTemplate.queryForObject(countSql, Integer.class, keyword);
 
 		return PageableExecutionUtils.getPage(content, pageable, () -> total != null ? total : 0);
-	}
-
-	private static String buildBooleanKeyword(String keyword) {
-		return '"' + keyword.trim().toLowerCase(Locale.ROOT) + "*\"";
 	}
 
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -10,6 +10,8 @@ CREATE TABLE IF NOT EXISTS terms (
 
     -- ngram 기반 FULLTEXT 인덱스
     FULLTEXT INDEX idx_title_description (title, description) WITH PARSER ngram,
+    FULLTEXT INDEX idx_description (description) WITH PARSER ngram,
+    FULLTEXT INDEX idx_title (title) WITH PARSER ngram,
 
     -- 일반 B-Tree 인덱스
     INDEX idx_initial (initial)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #141 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

이전에는 id DESC 기반이어서 필터링 이후에 정렬은 최신 항목이 우선 노출되었습니다.
이번 변경으로 검색어는 BOOLEAN MODE로 필터링하고, NATURAL MODE의 score를 사용해 정확도 기반으로 정렬합니다.

### 기존 검색 로직
- NATURAL MODE로 필터링
- ORDER BY id DESC로 최신순으로 정렬
<img width="505" height="782" alt="스크린샷 2025-07-15 오후 3 35 53" src="https://github.com/user-attachments/assets/e6bad1b6-0fb1-4a64-b837-a6b4ff1bffd8" />
<img width="477" height="439" alt="스크린샷 2025-07-15 오후 4 44 29" src="https://github.com/user-attachments/assets/acbe6b1f-9ea1-41da-862e-d9329fee1dac" />

"경제" 검색 결과

### 개선 검색 로직
- BOOLEAN MODE로 (접두사, 불용어 제어) 필터링 후
- NATURAL MODE로 score 계산. 이때 제목에 본문보다 높은 가중치 부여
- score를 바탕으로 정렬해 정확도가 높은 결과가 우선 노출

<img width="861" height="453" alt="스크린샷 2025-07-15 오후 3 41 48" src="https://github.com/user-attachments/assets/26bfe69c-99d7-4eb7-a557-585d45a75779" />
<img width="706" height="278" alt="스크린샷 2025-07-15 오후 4 46 04" src="https://github.com/user-attachments/assets/db3e8a9d-5fa5-4d3c-b12d-6c15f3557125" />


제목에 가중치 부여 전에는 제목에 경제가 들어있는 것 보다, 본문에만 경제가 포함된 결과가 더 높게 나오는 경우 발생
이를 해결하기 위해 제목, 본문에 각각 인덱스 추가 후 가중치 부여


## 💬리뷰 요구사항(선택)

```sql
ALTER TABLE terms
  ADD FULLTEXT INDEX ft_title       (title),
  ADD FULLTEXT INDEX ft_description (description);
```
위 SQL로 인덱스 추가해놓겠습닌다!