### PR TITLE
Feat : 알림 구독 해제 기능 추가 및 연결 상태 체크 로직 개선 (#143)

### DIFF
--- a/src/main/java/com/ripple/BE/notification/application/redis/RedisNotificationSubscriber.java
+++ b/src/main/java/com/ripple/BE/notification/application/redis/RedisNotificationSubscriber.java
@@ -25,6 +25,12 @@ public class RedisNotificationSubscriber {
 
             // SseEmitterManager를 통해 해당 알림을 구독 중인 클라이언트에게 전송
             String receiverId = notificationSseDTO.receiverId().toString();
+
+            // EmitterManager가 emitter 상태를 체크하도록 수정
+            if (!sseEmitterManager.isConnected(receiverId)) {
+                return;
+            }
+
             sseEmitterManager.pushNotification(receiverId, notificationSseDTO);
 
         } catch (Exception e) {

--- a/src/main/java/com/ripple/BE/notification/application/sse/SseEmitterManager.java
+++ b/src/main/java/com/ripple/BE/notification/application/sse/SseEmitterManager.java
@@ -154,4 +154,29 @@ public class SseEmitterManager {
                     }
                 });
     }
+
+    /** 사용자의 Emiiter 닫기 */
+    public void closeEmitter(String clientId) {
+        if (Boolean.TRUE.equals(emitterClosedMap.getOrDefault(clientId, false))) {
+            return;
+        }
+
+        emitterClosedMap.put(clientId, true);
+        stopHeartbeat(clientId);
+        SseEmitter emitter = emitterMap.remove(clientId);
+
+        if (emitter != null) {
+            try {
+                emitter.complete();
+            } catch (Exception e) {
+                log.warn("Emitter 종료 중 예외 발생: {}", clientId, e);
+            }
+        } else {
+            log.warn("Emitter가 존재하지 않습니다: {}", clientId);
+        }
+    }
+
+    public boolean isConnected(String clientId) {
+        return !Boolean.TRUE.equals(emitterClosedMap.getOrDefault(clientId, false));
+    }
 }

--- a/src/main/java/com/ripple/BE/notification/controller/NotificationController.java
+++ b/src/main/java/com/ripple/BE/notification/controller/NotificationController.java
@@ -41,6 +41,15 @@ public class NotificationController {
         return sseEmitterManager.connect(currentUser.getId().toString());
     }
 
+    @Operation(summary = "알림 구독 해제", description = "알림 구독을 해제합니다. 클라이언트에서 연결을 종료하면 자동으로 해제됩니다.")
+    @PostMapping("/unsubscribe")
+    public ResponseEntity<ApiResponse<Object>> unsubscribe(
+            final @AuthenticationPrincipal CustomUserDetails currentUser) {
+
+        sseEmitterManager.closeEmitter(currentUser.getId().toString());
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
+    }
+
     @Operation(summary = "알림 삭제", description = "알림을 삭제합니다.")
     @DeleteMapping("/{notificationId}")
     public ResponseEntity<ApiResponse<Object>> deleteNotification(


### PR DESCRIPTION
## #️⃣연관된 이슈

> #143 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

알람 구독 해제 api를 구현했습니다.
subscribe할때 emitter의 상태를 확인하고 커넥션이 닫혀있으면 알람을 전송하지 않습니다.

swagger에서는 테스트가 어려워 postman으로 테스트한 결과입니다.
<img width="987" height="662" alt="스크린샷 2025-07-23 오후 8 27 25" src="https://github.com/user-attachments/assets/fbe8de3a-39b3-4711-a261-7a75f6c28139" />

알람 구독중인 상황에서는 keep alive가 지속적으로 확인되며 댓글이 달리면 알람이 옵니다.

<img width="993" height="661" alt="스크린샷 2025-07-23 오후 8 27 46" src="https://github.com/user-attachments/assets/af3556a0-1365-42f2-92da-6c9b93c57c81" />

알람 구독 해제시에는 close 메세지가 나오고 댓글이 달려도 추가적으로 알람이 오지않습니다.


## 💬리뷰 요구사항(선택)

>  프론트에 알람 해제시 api/v1/user/alarm과 unscribe api를 같이 호출하도록 전달하도록 하겠습니다.
포스트맨으로 테스트해봤는데 더 좋은방법있으면 남겨주셔도 됩니다!~