### PR TITLE
Feat : 사용자 정보 DTO에 알림 상태 필드 추가 (#145)

### DIFF
--- a/src/main/java/com/ripple/BE/user/dto/UserInfoDTO.java
+++ b/src/main/java/com/ripple/BE/user/dto/UserInfoDTO.java
@@ -16,4 +16,5 @@ public record UserInfoDTO(
         Long currentStreak,
         Level level,
         Long quizCorrectRate,
-        Boolean isLevelTestCompleted) {}
+        Boolean isLevelTestCompleted,
+        Boolean isAlarmOn) {}

--- a/src/main/java/com/ripple/BE/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/ripple/BE/user/dto/response/UserInfoResponse.java
@@ -16,7 +16,8 @@ public record UserInfoResponse(
         Long currentStreak,
         Level level,
         Long quizCorrectRate,
-        Boolean isLevelTestCompleted) {
+        Boolean isLevelTestCompleted,
+        Boolean isAlarmOn) {
 
     public static UserInfoResponse toUserInfoResponse(UserInfoDTO userInfoDTO) {
         return new UserInfoResponse(
@@ -30,6 +31,7 @@ public record UserInfoResponse(
                 userInfoDTO.currentStreak(),
                 userInfoDTO.level(),
                 userInfoDTO.quizCorrectRate(),
-                userInfoDTO.isLevelTestCompleted());
+                userInfoDTO.isLevelTestCompleted(),
+                userInfoDTO.isAlarmOn());
     }
 }

--- a/src/main/java/com/ripple/BE/user/service/UserService.java
+++ b/src/main/java/com/ripple/BE/user/service/UserService.java
@@ -202,6 +202,7 @@ public class UserService {
                 .level(user.getCurrentLevel())
                 .quizCorrectRate(quizCorrectRate)
                 .isLevelTestCompleted(user.isLevelTestCompleted())
+                .isAlarmOn(user.isCoummunityAlarmAllowed())
                 .build();
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #145 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 사용자 정보 DTO에 알림 상태 필드 추가했습니다.
<img width="587" height="389" alt="스크린샷 2025-07-29 오전 12 02 04" src="https://github.com/user-attachments/assets/4a383dea-f7a0-45e7-bf1b-0f2d774a109e" />




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?