### PR TITLE
[Feat] 뉴스 인기순 조회 시 오늘 기준 데이터만 반환 (#140)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ dependencies {
 
     //spring AI
     implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter:0.8.0'
-    
+
     // JACKSON
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
@@ -107,7 +107,7 @@ dependencies {
     implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
-clean {	delete file('src/main/generated')}
+clean { delete file('src/main/generated') }
 
 tasks.named('test') {
     useJUnitPlatform()

--- a/src/main/java/com/ripple/BE/news/persistence/NewsRepository.java
+++ b/src/main/java/com/ripple/BE/news/persistence/NewsRepository.java
@@ -20,7 +20,7 @@ public interface NewsRepository {
 
     Optional<News> findById(long id); // 뉴스 ID로 조회
 
-    void save(News news); // 뉴스 저장
+    News save(News news); // 뉴스 저장
 
     void saveAllNews(List<News> newsList); // 뉴스 목록 저장
 

--- a/src/main/java/com/ripple/BE/news/persistence/impl/NewsRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/news/persistence/impl/NewsRepositoryImpl.java
@@ -48,8 +48,8 @@ public class NewsRepositoryImpl implements NewsRepository {
     }
 
     @Override
-    public void save(final News news) {
-        newsJpaRepository.save(NewsJpaEntity.from(news));
+    public News save(final News news) {
+        return newsJpaRepository.save(NewsJpaEntity.from(news)).toModel();
     }
 
     @Override

--- a/src/main/java/com/ripple/BE/news/persistence/jpa/repository/news/NewsQueryRepositoryImpl.java
+++ b/src/main/java/com/ripple/BE/news/persistence/jpa/repository/news/NewsQueryRepositoryImpl.java
@@ -11,6 +11,9 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ripple.BE.news.domain.type.NewsCategory;
 import com.ripple.BE.news.domain.type.NewsSort;
 import com.ripple.BE.news.persistence.dto.NewsWithScrapDTO;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -28,6 +31,10 @@ public class NewsQueryRepositoryImpl implements NewsQueryRepository {
 
         BooleanExpression predicate = newsJpaEntity.category.eq(category);
 
+        if (newsSort == NewsSort.POPULAR) {
+            predicate = predicate.and(getTodayPredicate());
+        }
+
         List<NewsWithScrapDTO> results =
                 getNewsWithScrapByPageable(pageable, predicate, newsSort, userId);
 
@@ -39,9 +46,17 @@ public class NewsQueryRepositoryImpl implements NewsQueryRepository {
 
     @Override
     public Page<NewsWithScrapDTO> findAll(Pageable pageable, NewsSort newsSort, long userId) {
-        List<NewsWithScrapDTO> results = getNewsWithScrapByPageable(pageable, null, newsSort, userId);
+        BooleanExpression predicate = null;
 
-        JPAQuery<Long> countQuery = queryFactory.select(newsJpaEntity.count()).from(newsJpaEntity);
+        if (newsSort == NewsSort.POPULAR) {
+            predicate = getTodayPredicate();
+        }
+
+        List<NewsWithScrapDTO> results =
+                getNewsWithScrapByPageable(pageable, predicate, newsSort, userId);
+
+        JPAQuery<Long> countQuery =
+                queryFactory.select(newsJpaEntity.count()).from(newsJpaEntity).where(predicate);
 
         return PageableExecutionUtils.getPage(results, pageable, countQuery::fetchOne);
     }
@@ -79,5 +94,13 @@ public class NewsQueryRepositoryImpl implements NewsQueryRepository {
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
+    }
+
+    private BooleanExpression getTodayPredicate() {
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atTime(LocalTime.MIN);
+        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+
+        return newsJpaEntity.pubDate.between(startOfDay, endOfDay);
     }
 }

--- a/src/test/java/com/ripple/BE/news/application/NewsServiceTest.java
+++ b/src/test/java/com/ripple/BE/news/application/NewsServiceTest.java
@@ -1,0 +1,258 @@
+package com.ripple.BE.news.application;
+
+import static com.ripple.BE.news.exception.errorcode.NewsErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import com.ripple.BE.news.domain.News;
+import com.ripple.BE.news.domain.NewsScrap;
+import com.ripple.BE.news.domain.type.NewsCategory;
+import com.ripple.BE.news.domain.type.NewsSort;
+import com.ripple.BE.news.dto.response.NewsPreviewListResponseDTO;
+import com.ripple.BE.news.dto.response.NewsResponseDTO;
+import com.ripple.BE.news.exception.NewsException;
+import com.ripple.BE.news.persistence.NewsRepository;
+import com.ripple.BE.news.persistence.NewsScrapRepository;
+import com.ripple.BE.news.persistence.dto.NewsWithScrapDTO;
+import com.ripple.BE.user.service.AttendanceService;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class NewsServiceTest {
+
+    NewsService newsService;
+
+    @Mock NewsRepository newsRepository;
+    @Mock NewsScrapRepository newsScrapRepository;
+    @Mock AttendanceService attendanceService;
+
+    @BeforeEach
+    void setUp() {
+        newsService = new NewsService(newsRepository, newsScrapRepository, attendanceService);
+    }
+
+    private NewsWithScrapDTO createNewsDto(
+            long id, String title, LocalDateTime date, long viewCount, NewsCategory category) {
+        return new NewsWithScrapDTO(
+                id, title, "요약", "내용", "http://example.com/news/" + id, category, viewCount, date, false);
+    }
+
+    @Test
+    @DisplayName("뉴스 상세 조회 시 조회수가 1 증가하고, DTO로 반환되며 퀘스트 완료가 호출된다")
+    void getNews_ShouldIncreaseViewCount_AndReturnDTO() {
+        // given
+        long newsId = 1L;
+        long userId = 1L;
+        News news =
+                News.withId(
+                        newsId,
+                        "테스트 뉴스",
+                        "내용",
+                        "발행자",
+                        3,
+                        "http://example.com/news/1",
+                        NewsCategory.ECONOMIC_ANALYSIS,
+                        LocalDateTime.now());
+
+        given(newsRepository.findByIdForUpdate(newsId)).willReturn(Optional.of(news));
+        given(newsRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        NewsResponseDTO response = newsService.getNews(newsId, userId);
+
+        // then
+        assertThat(response.views()).isEqualTo(4);
+        assertThat(response.title()).isEqualTo("테스트 뉴스");
+        assertThat(response.content()).isEqualTo("내용");
+        assertThat(response.publisher()).isEqualTo("발행자");
+
+        verify(newsRepository).findByIdForUpdate(newsId);
+        verify(newsRepository).save(any(News.class));
+        verify(attendanceService).completeQuest(userId, "ARTICLE");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 뉴스 ID로 조회 시 예외가 발생한다")
+    void getNews_ShouldThrowException_WhenNewsNotFound() {
+        // given
+        long newsId = 1L;
+        long userId = 1L;
+
+        given(newsRepository.findByIdForUpdate(newsId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> newsService.getNews(newsId, userId))
+                .isInstanceOf(NewsException.class)
+                .extracting("errorCode")
+                .isEqualTo(NEWS_NOT_FOUND);
+
+        verify(newsRepository).findByIdForUpdate(newsId);
+        verify(newsRepository, never()).save(any());
+        verify(attendanceService, never()).completeQuest(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("카테고리 없이 뉴스 목록 요청 시 findAll이 호출되어야 한다")
+    void getNewsList_ShouldUseFindAll_WhenCategoryIsNull() {
+        // given
+        int page = 0;
+        long userId = 1L;
+        NewsSort sort = NewsSort.RECENT;
+        Pageable pageable = PageRequest.of(page, 10);
+
+        NewsWithScrapDTO news1 =
+                createNewsDto(2L, "최신 뉴스", LocalDateTime.now(), 20, NewsCategory.ECONOMIC_POLICY);
+        NewsWithScrapDTO news2 =
+                createNewsDto(
+                        1L, "오래된 뉴스", LocalDateTime.now().minusDays(2), 10, NewsCategory.ECONOMIC_ANALYSIS);
+
+        given(newsRepository.findAll(pageable, sort, userId))
+                .willReturn(new PageImpl<>(List.of(news1, news2)));
+
+        // when
+        NewsPreviewListResponseDTO response = newsService.getNewsList(page, sort, null, userId);
+
+        // then
+        assertThat(response.newsList()).hasSize(2);
+        assertThat(response.newsList().get(0).title()).isEqualTo("최신 뉴스");
+
+        verify(newsRepository).findAll(pageable, sort, userId);
+        verify(newsRepository, never()).findByCategory(any(), any(), any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("카테고리가 존재하면 findByCategory가 호출되어야 한다")
+    void getNewsList_ShouldUseFindByCategory_WhenCategoryProvided() {
+        // given
+        int page = 0;
+        long userId = 2L;
+        NewsSort sort = NewsSort.RECENT;
+        NewsCategory category = NewsCategory.ECONOMIC_POLICY;
+        Pageable pageable = PageRequest.of(page, 10);
+
+        NewsWithScrapDTO news1 = createNewsDto(3L, "정책 뉴스1", LocalDateTime.now(), 30, category);
+        NewsWithScrapDTO news2 =
+                createNewsDto(4L, "정책 뉴스2", LocalDateTime.now().minusDays(1), 5, category);
+
+        given(newsRepository.findByCategory(category, sort, pageable, userId))
+                .willReturn(new PageImpl<>(List.of(news1, news2)));
+
+        // when
+        NewsPreviewListResponseDTO response = newsService.getNewsList(page, sort, category, userId);
+
+        // the
+        assertThat(response.newsList()).hasSize(2);
+        assertThat(response.newsList().get(0).title()).isEqualTo("정책 뉴스1");
+
+        verify(newsRepository).findByCategory(category, sort, pageable, userId);
+        verify(newsRepository, never()).findAll(any(), any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("뉴스 스크랩 추가 시 뉴스가 존재하지 않으면 예외가 발생한다")
+    void addScrap_ShouldThrow_WhenNewsNotFound() {
+        // given
+        long userId = 1L;
+        long newsId = 100L;
+
+        given(newsRepository.findById(newsId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> newsService.addScrapToNews(newsId, userId))
+                .isInstanceOf(NewsException.class)
+                .extracting("errorCode")
+                .isEqualTo(NEWS_NOT_FOUND);
+
+        verify(newsRepository).findById(newsId);
+        verify(newsScrapRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("뉴스 스크랩 추가 시 이미 스크랩된 뉴스면 예외가 발생한다")
+    void addScrap_ShouldThrow_WhenAlreadyScrapped() {
+        // given
+        long userId = 1L;
+        long newsId = 101L;
+
+        News news =
+                News.withId(
+                        newsId, "제목", "내용", "발행자", 0, "url", NewsCategory.ECONOMIC_POLICY, LocalDateTime.now());
+        given(newsRepository.findById(newsId)).willReturn(Optional.of(news));
+        given(newsScrapRepository.existsByNewsIdAndUserId(newsId, userId)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> newsService.addScrapToNews(newsId, userId))
+                .isInstanceOf(NewsException.class)
+                .extracting("errorCode")
+                .isEqualTo(NEWS_SCRAP_ALREADY_EXIST);
+
+        verify(newsScrapRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("뉴스 스크랩 추가 시 유효한 경우 스크랩이 저장되어야 한다")
+    void addScrap_ShouldSave_WhenValid() {
+        // given
+        long userId = 1L;
+        long newsId = 102L;
+
+        News news =
+                News.withId(
+                        newsId, "제목", "내용", "발행자", 0, "url", NewsCategory.ECONOMIC_POLICY, LocalDateTime.now());
+
+        given(newsRepository.findById(newsId)).willReturn(Optional.of(news));
+        given(newsScrapRepository.existsByNewsIdAndUserId(newsId, userId)).willReturn(false);
+
+        // when
+        newsService.addScrapToNews(newsId, userId);
+
+        // then
+        verify(newsScrapRepository).save(any(NewsScrap.class));
+    }
+
+    @Test
+    @DisplayName("뉴스 스크랩 삭제 시 스크랩이 존재하지 않으면 예외가 발생한다")
+    void removeScrap_ShouldThrow_WhenNotFound() {
+        // given
+        long userId = 1L;
+        long newsId = 103L;
+
+        given(newsScrapRepository.findByNewsIdAndUserId(newsId, userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> newsService.removeScrapFromNews(newsId, userId))
+                .isInstanceOf(NewsException.class)
+                .extracting("errorCode")
+                .isEqualTo(NEWS_SCRAP_NOT_FOUND);
+
+        verify(newsScrapRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("뉴스 스크랩 삭제 시 스크랩이 존재하면 삭제된다")
+    void removeScrap_ShouldDelete_WhenExists() {
+        // given
+        long userId = 1L;
+        long newsId = 104L;
+
+        NewsScrap scrap = NewsScrap.withId(1L, userId, newsId);
+        given(newsScrapRepository.findByNewsIdAndUserId(newsId, userId)).willReturn(Optional.of(scrap));
+
+        // when
+        newsService.removeScrapFromNews(newsId, userId);
+
+        // then
+        verify(newsScrapRepository).delete(scrap);
+    }
+}

--- a/src/test/java/com/ripple/BE/news/persistence/NewsRepositoryTest.java
+++ b/src/test/java/com/ripple/BE/news/persistence/NewsRepositoryTest.java
@@ -1,0 +1,323 @@
+package com.ripple.BE.news.persistence;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.ripple.BE.global.config.JpaConfig;
+import com.ripple.BE.global.config.QuerydslConfig;
+import com.ripple.BE.news.domain.News;
+import com.ripple.BE.news.domain.NewsScrap;
+import com.ripple.BE.news.domain.type.NewsCategory;
+import com.ripple.BE.news.domain.type.NewsSort;
+import com.ripple.BE.news.persistence.dto.NewsWithScrapDTO;
+import com.ripple.BE.news.persistence.impl.NewsRepositoryImpl;
+import com.ripple.BE.news.persistence.impl.NewsScrapRepositoryImpl;
+import com.ripple.BE.news.persistence.jdbc.NewsJdbcRepository;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import({
+    NewsRepositoryImpl.class,
+    NewsJdbcRepository.class,
+    NewsScrapRepositoryImpl.class,
+    QuerydslConfig.class,
+    JpaConfig.class
+})
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class NewsRepositoryTest {
+
+    @Autowired private NewsRepository newsRepository;
+    @Autowired private NewsScrapRepository newsScrapRepository;
+    @Autowired private EntityManager entityManager;
+
+    private static final Pageable DEFAULT_PAGE = Pageable.ofSize(10);
+    private static final long USER_ID = 1L;
+
+    private News createNews(
+            String title, int views, String url, NewsCategory category, LocalDateTime pubDate) {
+        return News.withoutId(title, "내용", "리플", views, url, category, pubDate);
+    }
+
+    private News createAndSaveNews(String title) {
+        return newsRepository.save(
+                createNews(title, 0, title + ".com", NewsCategory.ECONOMIC_ANALYSIS, LocalDateTime.now()));
+    }
+
+    @Test
+    @DisplayName("뉴스 저장 후 ID가 생성되고 데이터가 일치해야 한다")
+    void saveNews() {
+        // given
+        News news1 = createNews("뉴스1", 0, "url1", NewsCategory.ECONOMIC_ANALYSIS, LocalDateTime.now());
+        News news2 = createNews("뉴스2", 0, "url2", NewsCategory.ECONOMIC_ANALYSIS, LocalDateTime.now());
+
+        // when
+        News saved1 = newsRepository.save(news1);
+        News saved2 = newsRepository.save(news2);
+
+        // then
+        assertAll(
+                () -> assertNotNull(saved1.getId()),
+                () -> assertNotNull(saved2.getId()),
+                () -> assertEquals("뉴스1", saved1.getTitle()),
+                () -> assertEquals("뉴스2", saved2.getTitle()));
+    }
+
+    @Test
+    @DisplayName("뉴스 ID로 조회 시 데이터가 일치해야 한다")
+    void findById() {
+        // given
+        News saved = createAndSaveNews("뉴스");
+
+        // when
+        Optional<News> found = newsRepository.findById(saved.getId());
+
+        // then
+        assertTrue(found.isPresent());
+        assertEquals(saved.getTitle(), found.get().getTitle());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 ID로 조회하면 Optional.empty()를 반환해야 한다")
+    void findById_NotFound() {
+        assertTrue(newsRepository.findById(999L).isEmpty());
+    }
+
+    @Test
+    @DisplayName("뉴스 ID로 비관적 락 조회 시 데이터가 일치해야 한다")
+    void findByIdForUpdate() {
+        // given
+        News saved = createAndSaveNews("뉴스 락 테스트");
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        Optional<News> found = newsRepository.findByIdForUpdate(saved.getId());
+
+        // then
+        assertTrue(found.isPresent());
+        assertEquals(saved.getTitle(), found.get().getTitle());
+    }
+
+    @Test
+    @DisplayName("비관적 락 조회 시 존재하지 않는 ID면 빈 Optional을 반환해야 한다")
+    void findByIdForUpdate_NotFound() {
+        assertTrue(newsRepository.findByIdForUpdate(999L).isEmpty());
+    }
+
+    @Test
+    @DisplayName("뉴스 목록을 saveAllNews로 저장하면 모두 저장되어야 한다")
+    void saveAllNewsTest() {
+        // given
+        News news1 =
+                createNews(
+                        "배치 저장 뉴스1", 0, "batch-url1", NewsCategory.ECONOMIC_ANALYSIS, LocalDateTime.now());
+        News news2 =
+                createNews(
+                        "배치 저장 뉴스2", 0, "batch-url2", NewsCategory.ECONOMIC_ANALYSIS, LocalDateTime.now());
+
+        // when
+        newsRepository.saveAllNews(List.of(news1, news2));
+
+        // then
+        List<String> urls = List.of("batch-url1", "batch-url2");
+        List<String> existingUrls = newsRepository.findExistingUrls(urls);
+
+        assertEquals(2, existingUrls.size());
+        assertTrue(existingUrls.containsAll(urls));
+    }
+
+    @Test
+    @DisplayName("최신순으로 뉴스 전체 조회 시 최신 뉴스가 먼저 와야 한다")
+    void findAll_SortedByRecent() {
+        // given
+        News old =
+                createNews(
+                        "오래된 뉴스",
+                        0,
+                        "url-old",
+                        NewsCategory.ECONOMIC_ANALYSIS,
+                        LocalDateTime.now().minusDays(1));
+        News recent =
+                createNews("최신 뉴스", 0, "url-new", NewsCategory.ECONOMIC_ANALYSIS, LocalDateTime.now());
+        News veryOld =
+                createNews(
+                        "아주 오래된 뉴스",
+                        0,
+                        "url-very-old",
+                        NewsCategory.ECONOMIC_ANALYSIS,
+                        LocalDateTime.now().minusDays(2));
+        newsRepository.saveAllNews(List.of(old, recent, veryOld));
+
+        // when
+        Page<NewsWithScrapDTO> result = newsRepository.findAll(DEFAULT_PAGE, NewsSort.RECENT, USER_ID);
+
+        // then
+        assertEquals("최신 뉴스", result.getContent().get(0).title());
+        assertEquals("오래된 뉴스", result.getContent().get(1).title());
+        assertEquals("아주 오래된 뉴스", result.getContent().get(2).title());
+    }
+
+    @Test
+    @DisplayName("조회수순으로 오늘 뉴스만 조회되어야 하며, 조회수가 높은 뉴스가 먼저 나와야 한다")
+    void findAll_SortedByView_TodayOnly() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+
+        News high = createNews("조회수 많음", 100, "url1", NewsCategory.ECONOMIC_ANALYSIS, now);
+        News low = createNews("조회수 적음", 1, "url2", NewsCategory.ECONOMIC_ANALYSIS, now);
+        News yesterday =
+                createNews("어제 뉴스", 999, "url3", NewsCategory.ECONOMIC_ANALYSIS, now.minusDays(1));
+        newsRepository.saveAllNews(List.of(high, low, yesterday));
+
+        // when
+        Page<NewsWithScrapDTO> result = newsRepository.findAll(DEFAULT_PAGE, NewsSort.POPULAR, USER_ID);
+
+        // then
+        assertEquals(2, result.getContent().size());
+        assertEquals("조회수 많음", result.getContent().get(0).title());
+    }
+
+    @Test
+    @DisplayName("카테고리별 최신순 조회는 최신 뉴스가 먼저 나와야 한다")
+    void findByCategory_SortedByRecent() {
+        // given
+        NewsCategory category = NewsCategory.ECONOMIC_POLICY;
+        NewsCategory otherCategory = NewsCategory.ECONOMIC_ANALYSIS;
+
+        News old = createNews("오래된", 0, "old-url", category, LocalDateTime.now().minusDays(1));
+        News recent = createNews("최신", 0, "new-url", category, LocalDateTime.now());
+        News other = createNews("다른 카테고리", 0, "other-url", otherCategory, LocalDateTime.now());
+        newsRepository.saveAllNews(List.of(old, recent, other));
+
+        // when
+        Page<NewsWithScrapDTO> result =
+                newsRepository.findByCategory(category, NewsSort.RECENT, DEFAULT_PAGE, USER_ID);
+
+        // then
+        assertEquals(2, result.getContent().size());
+        assertEquals("최신", result.getContent().get(0).title());
+    }
+
+    @Test
+    @DisplayName("카테고리별 조회수순 조회 시 오늘 뉴스만 포함되어야 한다")
+    void findByCategory_SortedByView_TodayOnly() {
+        // given
+        NewsCategory category = NewsCategory.ECONOMIC_ANALYSIS;
+
+        News high = createNews("오늘 조회수 많음", 50, "urlA", category, LocalDateTime.now());
+        News low = createNews("오늘 조회수 적음", 5, "urlB", category, LocalDateTime.now());
+        News old = createNews("어제 뉴스", 999, "urlC", category, LocalDateTime.now().minusDays(1));
+        News otherCategory =
+                createNews("다른 카테고리 뉴스", 1000, "urlD", NewsCategory.ECONOMIC_POLICY, LocalDateTime.now());
+
+        newsRepository.saveAllNews(List.of(high, low, old, otherCategory));
+
+        // when
+        Page<NewsWithScrapDTO> result =
+                newsRepository.findByCategory(category, NewsSort.POPULAR, DEFAULT_PAGE, USER_ID);
+
+        // then
+        assertEquals(2, result.getContent().size());
+        assertEquals("오늘 조회수 많음", result.getContent().get(0).title());
+    }
+
+    @Test
+    @DisplayName("뉴스 전체 조회 시 페이징과 정렬이 적용되어야 한다")
+    void findAll_WithPagingAndSorting() {
+        // given
+        for (int i = 0; i < 15; i++) {
+            newsRepository.save(
+                    createNews("뉴스" + i, i, "url" + i, NewsCategory.ECONOMIC_ANALYSIS, LocalDateTime.now()));
+        }
+
+        // when
+        Page<NewsWithScrapDTO> result =
+                newsRepository.findAll(Pageable.ofSize(10).withPage(1), NewsSort.RECENT, USER_ID);
+
+        // then
+        assertEquals(5, result.getContent().size());
+        assertEquals(15, result.getTotalElements());
+    }
+
+    @Test
+    @DisplayName("카테고리별 뉴스 조회 시 페이징이 정상 동작해야 한다")
+    void findByCategory_WithPaging() {
+        // given
+        NewsCategory category = NewsCategory.ECONOMIC_POLICY;
+
+        for (int i = 0; i < 13; i++) {
+            newsRepository.save(createNews("뉴스" + i, i, "url" + i, category, LocalDateTime.now()));
+        }
+
+        // when
+        Page<NewsWithScrapDTO> page =
+                newsRepository.findByCategory(
+                        category, NewsSort.RECENT, Pageable.ofSize(10).withPage(1), USER_ID);
+
+        // then
+        assertEquals(3, page.getContent().size());
+        assertEquals(13, page.getTotalElements());
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 뉴스 URL만 반환되어야 한다")
+    void findExistingUrls() {
+        // given
+        News news1 = createNews("뉴스1", 0, "url1", NewsCategory.ECONOMIC_ANALYSIS, LocalDateTime.now());
+        News news2 = createNews("뉴스2", 0, "url2", NewsCategory.ECONOMIC_ANALYSIS, LocalDateTime.now());
+        News news3 = createNews("뉴스3", 0, "url3", NewsCategory.ECONOMIC_ANALYSIS, LocalDateTime.now());
+
+        newsRepository.saveAllNews(List.of(news1, news2));
+
+        // when
+        List<String> existingUrls = newsRepository.findExistingUrls(List.of("url1", "url2", "url3"));
+
+        // then
+        assertEquals(2, existingUrls.size());
+        assertTrue(existingUrls.contains(news1.getUrl()));
+        assertTrue(existingUrls.contains(news2.getUrl()));
+        assertFalse(existingUrls.contains(news3.getUrl()));
+    }
+
+    @Test
+    @DisplayName("스크랩한 뉴스는 isScrapped = true로 반환되어야 한다. 스크랩 하지 않은 뉴스는 false로 반환되어야 한다")
+    void isScrapedValue_ShouldBeTrue_WhenNewsIsScrapped() {
+        // given
+        News news1 =
+                createNews("스크랩 뉴스", 0, "scrap-url", NewsCategory.ECONOMIC_ANALYSIS, LocalDateTime.now());
+        News news2 =
+                createNews(
+                        "스크랩하지 않은 뉴스", 0, "unscrap-url", NewsCategory.ECONOMIC_ANALYSIS, LocalDateTime.now());
+        News savedNews1 = newsRepository.save(news1);
+        newsRepository.save(news2);
+
+        newsScrapRepository.save(NewsScrap.withoutId(USER_ID, savedNews1.getId()));
+
+        // when
+        Page<NewsWithScrapDTO> result = newsRepository.findAll(DEFAULT_PAGE, NewsSort.RECENT, USER_ID);
+
+        // then
+        result
+                .getContent()
+                .forEach(
+                        news -> {
+                            if (news.id().equals(savedNews1.getId())) {
+                                assertTrue(news.isScrapped());
+                            } else {
+                                assertFalse(news.isScrapped());
+                            }
+                        });
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -7,11 +7,10 @@ spring:
     name: ripple-test
 
   datasource:
-    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    username: SA
-    password:
-    driver-class-name: org.h2.Driver
-
+    url: jdbc:mysql://localhost:3306/test
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: '0000' # 무조건 ''로 감싸야 함
   data:
     redis:
       host: localhost
@@ -20,20 +19,14 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: false
     properties:
       hibernate:
-        format_sql: true
+        format_sql: false
         default_batch_fetch_size: 100
-
   sql:
     init:
-      mode: never
-
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+      mode: always
+      schema-locations: classpath:schema-test.sql
 
   ai:
     openai:
@@ -59,11 +52,11 @@ cloud:
 
 logging:
   level:
-    org.springframework.transaction: DEBUG
+    org.springframework.transaction: ERROR
     # org.hibernate.SQL: DEBUG  # SQL 로그도 보고 싶다면
-    org.hibernate.resource.transaction: DEBUG
-    org.springframework.transaction.interceptor: DEBUG
-    org.springframework.orm.jpa.JpaTransactionManager: DEBUG
+    org.hibernate.resource.transaction: ERROR
+    org.springframework.transaction.interceptor: ERROR
+    org.springframework.orm.jpa.JpaTransactionManager: ERROR
 
 swagger:
   server:

--- a/src/test/resources/schema-test.sql
+++ b/src/test/resources/schema-test.sql
@@ -1,0 +1,68 @@
+
+-- Term 테이블 생성 ---
+CREATE TABLE IF NOT EXISTS terms (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    created_date DATETIME(6) NOT NULL,
+    modified_date DATETIME(6) NOT NULL,
+    description TEXT NOT NULL,
+    initial VARCHAR(255) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+
+    -- ngram 기반 FULLTEXT 인덱스
+    FULLTEXT INDEX idx_title_description (title, description) WITH PARSER ngram,
+
+    -- 일반 B-Tree 인덱스
+    INDEX idx_initial (initial)
+) ENGINE=InnoDB;
+
+
+-- TermScrap 테이블 생성 ---
+CREATE TABLE IF NOT EXISTS term_scraps (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    created_date DATETIME(6) NOT NULL,
+    modified_date DATETIME(6) NOT NULL,
+    term_id BIGINT NULL,
+    user_id BIGINT NOT NULL
+);
+
+-- News 테이블 생성 ---
+CREATE TABLE IF NOT EXISTS news (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    created_date DATETIME(6) NOT NULL,
+    modified_date DATETIME(6) NOT NULL,
+    category ENUM(
+        'ECONOMIC_ANALYSIS', 'ECONOMIC_POLICY', 'FINANCE', 'GLOBAL',
+        'INDUSTRY', 'INVESTMENT', 'NORMAL', 'OTHER', 'REAL_ESTATE'
+    ) NOT NULL,
+    content VARCHAR(255) NULL,
+    pub_date DATETIME(6) NULL,
+    publisher VARCHAR(255) NULL,
+    title VARCHAR(255) NOT NULL,
+    url VARCHAR(255) NULL,
+    views BIGINT NOT NULL,
+
+    -- ngram 기반 FULLTEXT 인덱스
+    FULLTEXT INDEX idx_title_content (title, content) WITH PARSER ngram
+) ENGINE=InnoDB;
+
+-- NewsScrap 테이블 생성 ---
+CREATE TABLE IF NOT EXISTS news_scraps (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    created_date DATETIME(6) NOT NULL,
+    modified_date DATETIME(6) NOT NULL,
+    news_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL
+);
+
+-- Notification 테이블 생성 ---
+CREATE TABLE IF NOT EXISTS notification (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    created_date DATETIME(6) NOT NULL,
+    modified_date DATETIME(6) NOT NULL,
+    content VARCHAR(255) NOT NULL,
+    is_read BIT NOT NULL,
+    post_id BIGINT NULL,
+    user_id BIGINT NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    type ENUM('COMMENT', 'POPULAR', 'REPLY') NOT NULL
+);


### PR DESCRIPTION
## PR 내용

## #️⃣연관된 이슈

> Close #140

## 📝작업 내용

> 뉴스 인기순 조회 시 오늘 발행된 뉴스만 반환하도록 필터링 기능을 구현했습니다.

### 🎯 주요 변경사항

- **날짜 필터링 로직 추가**
  - `NewsQueryRepositoryImpl.getTodayPredicate()` 메소드 구현
  - `LocalDate.now()`를 기준으로 오늘 00:00:00 ~ 23:59:59 범위의 뉴스만 조회
  - `newsJpaEntity.pubDate.between(startOfDay, endOfDay)` 조건으로 필터링

- **조건부 필터링 적용**
  - `NewsSort.POPULAR`일 때만 오늘 날짜 필터링 적용
  - `NewsSort.RECENT`는 기존과 동일하게 모든 날짜의 뉴스 조회 유지
  - 전체 뉴스 조회(`findAll`)와 카테고리별 조회(`findByCategory`) 모두 적용

- **인터페이스 개선**
  - `NewsRepository.save()` 메소드 반환 타입을 `void`에서 `News`로 변경
  - 저장된 엔티티의 ID 확인이 가능하도록 개선하여 테스트 편의성 향상

### 🧪 테스트 코드 추가

- **NewsRepositoryTest 추가**
  - 뉴스 저장, 조회, 비관적 락, 배치 저장 테스트
  - 최신순/인기순 정렬 테스트
  - **오늘 기준 필터링 테스트**: `findAll_SortedByView_TodayOnly`, `findByCategory_SortedByView_TodayOnly`
  - 페이징, 스크랩 상태 확인 테스트

- **NewsServiceTest 추가**
  - 뉴스 상세 조회 및 조회수 증가 테스트
  - 스크랩 추가/삭제 기능 테스트
  - 뉴스 목록 조회 (전체/카테고리별) 테스트
  - 예외 상황 처리 테스트

### 🔧 테스트 환경 개선

- **데이터베이스 설정 변경**
  - H2 메모리 DB에서 MySQL 테스트 환경으로 변경
  - `schema-test.sql` 파일 추가로 테스트용 스키마 자동 초기화
  - 로그 레벨 조정으로 테스트 출력 최적화

### 📊 동작 방식

```java
// 인기순 조회 시
if (newsSort == NewsSort.POPULAR) {
    predicate = predicate.and(getTodayPredicate());
}

// 오늘 날짜 범위 생성
private BooleanExpression getTodayPredicate() {
    LocalDate today = LocalDate.now();
    LocalDateTime startOfDay = today.atTime(LocalTime.MIN); // 00:00:00
    LocalDateTime endOfDay = today.atTime(LocalTime.MAX);   // 23:59:59
    return newsJpaEntity.pubDate.between(startOfDay, endOfDay);
}
```

### ✅ 테스트 검증 완료

- 모든 기존 테스트 통과
- 새로 추가된 오늘 기준 필터링 테스트 통과
- 최신순 조회는 기존 동작 유지 확인
- 인기순 조회는 오늘 발행된 뉴스만 반환 확인

## 💬리뷰 요구사항(선택)

> - `getTodayPredicate()` 메소드의 날짜 범위 처리 로직이 적절한지 검토 부탁드립니다.
> - 시간대(timezone) 처리가 필요한지 의견 부탁드립니다.
> - 테스트 환경을 H2에서 MySQL로 변경한 것이 적절한지 확인 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.ai/code)